### PR TITLE
[#6] OAuth2 소셜 로그인, 회원가입 및 JWT 인증 구현

### DIFF
--- a/.github/workflows/sonarcloud-analyze.yml
+++ b/.github/workflows/sonarcloud-analyze.yml
@@ -12,16 +12,6 @@ jobs:
   CodeAnalyze:
     runs-on: ubuntu-latest
 
-    env:
-      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-      AWS_S3_POST_BUCKET: ${{ secrets.AWS_S3_POST_BUCKET }}
-      AWS_S3_REGION: ${{ secrets.AWS_S3_REGION }}
-      DB_USERNAME: ${{ secrets.DB_USERNAME }}
-      DB_PASSWORD: ${{ secrets.DB_PASSWORD }}
-      DB_URL: ${{ secrets.DB_URL }}
-      SERVER_PORT: ${{ secrets.SERVER_PORT }}
-
     steps:
       - uses: actions/checkout@v3
         with:

--- a/build.gradle
+++ b/build.gradle
@@ -31,10 +31,18 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
+	implementation 'org.springframework.boot:spring-boot-starter-security'
+	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
 
+	// S3
 	implementation platform("software.amazon.awssdk:bom:${awsSdkVersion}")   	// SDK v2 BOM – 다중 모듈 버전 통일
 	implementation 'software.amazon.awssdk:s3'                                 	// S3 클라이언트 모듈만 사용
 	implementation 'org.apache.tika:tika-core:2.9.0'							// 실제 콘텐츠 타입을 판별을 위해 사용
+
+	// JWT
+	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
+	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 
     compileOnly 'org.projectlombok:lombok'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'

--- a/src/main/java/flab/transtalk/auth/config/SecurityConfig.java
+++ b/src/main/java/flab/transtalk/auth/config/SecurityConfig.java
@@ -1,0 +1,41 @@
+package flab.transtalk.auth.config;
+
+import flab.transtalk.auth.security.jwt.JwtAuthenticationFilter;
+import flab.transtalk.auth.service.CustomOAuth2UserService;
+import flab.transtalk.auth.security.oauth.OAuth2SuccessHandler;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
+public class SecurityConfig {
+
+    private final JwtAuthenticationFilter jwtAuthenticationFilter;
+    private final CustomOAuth2UserService customOAuth2UserService;
+    private final OAuth2SuccessHandler oAuth2SuccessHandler;
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http
+                .csrf(csrf -> csrf.disable())
+                .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers("/", "/oauth2/**", "/login/**").permitAll()
+                        .anyRequest().authenticated()
+                )
+                .oauth2Login(oauth2 -> oauth2
+                        .userInfoEndpoint(userInfo -> userInfo.userService(customOAuth2UserService))
+                        .successHandler(oAuth2SuccessHandler)
+                );
+
+        http.addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
+        return http.build();
+    }
+}

--- a/src/main/java/flab/transtalk/auth/config/SecurityConfig.java
+++ b/src/main/java/flab/transtalk/auth/config/SecurityConfig.java
@@ -1,5 +1,6 @@
 package flab.transtalk.auth.config;
 
+import flab.transtalk.auth.security.jwt.JwtAuthenticationEntryPoint;
 import flab.transtalk.auth.security.jwt.JwtAuthenticationFilter;
 import flab.transtalk.auth.service.CustomOAuth2UserService;
 import flab.transtalk.auth.security.oauth.OAuth2SuccessHandler;
@@ -18,6 +19,7 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 public class SecurityConfig {
 
     private final JwtAuthenticationFilter jwtAuthenticationFilter;
+    private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
     private final CustomOAuth2UserService customOAuth2UserService;
     private final OAuth2SuccessHandler oAuth2SuccessHandler;
 
@@ -36,6 +38,8 @@ public class SecurityConfig {
                 );
 
         http.addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
+        http.exceptionHandling(ex -> ex
+                .authenticationEntryPoint(jwtAuthenticationEntryPoint));
         return http.build();
     }
 }

--- a/src/main/java/flab/transtalk/auth/domain/AuthAccount.java
+++ b/src/main/java/flab/transtalk/auth/domain/AuthAccount.java
@@ -1,0 +1,35 @@
+package flab.transtalk.auth.domain;
+
+import flab.transtalk.user.domain.User;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(uniqueConstraints = {
+        @UniqueConstraint(name="uk_provider_pid", columnNames={"provider","provider_id"})
+})
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class AuthAccount {
+    @Id
+    @GeneratedValue(strategy = GenerationType.SEQUENCE)
+    @SequenceGenerator(
+            name = "auth_account_seq_gen",
+            sequenceName = "auth_account_seq"
+    )
+    @Column(name = "id", nullable = false)
+    private Long id;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private AuthProvider provider;
+
+    @Column(name = "provider_id", nullable = false)
+    private String providerId;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+}

--- a/src/main/java/flab/transtalk/auth/domain/AuthProvider.java
+++ b/src/main/java/flab/transtalk/auth/domain/AuthProvider.java
@@ -1,0 +1,5 @@
+package flab.transtalk.auth.domain;
+
+public enum AuthProvider {
+    GOOGLE
+}

--- a/src/main/java/flab/transtalk/auth/domain/ProviderInfo.java
+++ b/src/main/java/flab/transtalk/auth/domain/ProviderInfo.java
@@ -1,0 +1,62 @@
+package flab.transtalk.auth.domain;
+
+import flab.transtalk.auth.exception.message.JwtExceptionMessages;
+import flab.transtalk.user.domain.User;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Value;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+
+@Value
+@Getter
+public class ProviderInfo {
+
+    private final AuthProvider provider;
+    private final String providerId;
+
+    public static ProviderInfo fromUser(User user) {
+        return new ProviderInfo(user.getProvider(), user.getProviderId());
+    }
+
+    public static ProviderInfo fromSubject(String subject) {
+        String[] parts = subject.split(":", 2);
+        if (parts.length != 2) {
+            throw new IllegalArgumentException("Invalid subject format: " + subject);
+        }
+        AuthProvider provider;
+        String providerId;
+        try {
+            provider = AuthProvider.valueOf(parts[0]);;
+            providerId = parts[1];
+        } catch (IllegalArgumentException e) {
+            throw new OAuth2AuthenticationException(JwtExceptionMessages.AUTH_FAILED);
+        }
+        return new ProviderInfo(provider, providerId);
+    }
+
+    public String toSubject() {
+        return provider + ":" + providerId;
+    }
+
+    public static ProviderInfo fromOAuth2User(String registrationId, OAuth2User oAuth2User) {
+        AuthProvider provider = AuthProvider.valueOf(registrationId.toUpperCase());
+
+        String providerId;
+        switch (provider) {
+            case GOOGLE -> providerId = oAuth2User.getAttribute("sub");
+            default -> throw new OAuth2AuthenticationException(JwtExceptionMessages.AUTH_FAILED);
+        }
+
+        return new ProviderInfo(provider, providerId);
+    }
+
+    public String getNameAttributeKey() {
+        switch (provider) {
+            case GOOGLE -> {
+                return "sub";
+            }
+            default -> throw new OAuth2AuthenticationException(JwtExceptionMessages.AUTH_FAILED);
+        }
+    }
+}

--- a/src/main/java/flab/transtalk/auth/domain/ProviderInfo.java
+++ b/src/main/java/flab/transtalk/auth/domain/ProviderInfo.java
@@ -15,30 +15,6 @@ public class ProviderInfo {
     private final AuthProvider provider;
     private final String providerId;
 
-    public static ProviderInfo fromUser(User user) {
-        return new ProviderInfo(user.getProvider(), user.getProviderId());
-    }
-
-    public static ProviderInfo fromSubject(String subject) {
-        String[] parts = subject.split(":", 2);
-        if (parts.length != 2) {
-            throw new IllegalArgumentException("Invalid subject format: " + subject);
-        }
-        AuthProvider provider;
-        String providerId;
-        try {
-            provider = AuthProvider.valueOf(parts[0]);;
-            providerId = parts[1];
-        } catch (IllegalArgumentException e) {
-            throw new OAuth2AuthenticationException(JwtExceptionMessages.AUTH_FAILED);
-        }
-        return new ProviderInfo(provider, providerId);
-    }
-
-    public String toSubject() {
-        return provider + ":" + providerId;
-    }
-
     public static ProviderInfo fromOAuth2User(String registrationId, OAuth2User oAuth2User) {
         AuthProvider provider = AuthProvider.valueOf(registrationId.toUpperCase());
 

--- a/src/main/java/flab/transtalk/auth/exception/JwtAuthenticationException.java
+++ b/src/main/java/flab/transtalk/auth/exception/JwtAuthenticationException.java
@@ -6,10 +6,10 @@ import org.springframework.security.core.AuthenticationException;
 @Getter
 public class JwtAuthenticationException extends AuthenticationException {
 
-    private final String code;
+    private final JwtErrorCode errorCode;
 
-    public JwtAuthenticationException(String code, String message, Throwable cause) {
-        super(message, cause);
-        this.code = code;
+    public JwtAuthenticationException(JwtErrorCode errorCode, Throwable cause) {
+        super(errorCode.getMessage(), cause);
+        this.errorCode = errorCode;
     }
 }

--- a/src/main/java/flab/transtalk/auth/exception/JwtAuthenticationException.java
+++ b/src/main/java/flab/transtalk/auth/exception/JwtAuthenticationException.java
@@ -1,0 +1,15 @@
+package flab.transtalk.auth.exception;
+
+import lombok.Getter;
+import org.springframework.security.core.AuthenticationException;
+
+@Getter
+public class JwtAuthenticationException extends AuthenticationException {
+
+    private final String code;
+
+    public JwtAuthenticationException(String code, String message, Throwable cause) {
+        super(message, cause);
+        this.code = code;
+    }
+}

--- a/src/main/java/flab/transtalk/auth/exception/JwtErrorCode.java
+++ b/src/main/java/flab/transtalk/auth/exception/JwtErrorCode.java
@@ -1,0 +1,24 @@
+package flab.transtalk.auth.exception;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public enum JwtErrorCode {
+
+    TOKEN_EXPIRED    ("TOKEN_EXPIRED"   , "JWT 토큰이 만료되었습니다."      , HttpStatus.UNAUTHORIZED),
+    INVALID_SIGNATURE("INVALID_SIGNATURE", "JWT 서명이 올바르지 않습니다." , HttpStatus.UNAUTHORIZED),
+    MALFORMED_TOKEN  ("MALFORMED_TOKEN" , "잘못된 JWT 형식입니다."         , HttpStatus.BAD_REQUEST),
+    USER_NOT_FOUND   ("USER_NOT_FOUND"  , "유효하지 않는 사용자입니다."     , HttpStatus.UNAUTHORIZED),
+    AUTH_FAILED      ("AUTH_FAILED"     , "인증 실패"                     , HttpStatus.UNAUTHORIZED);
+
+    private final String code;
+    private final String message;
+    private final HttpStatus status;
+
+    JwtErrorCode(String code, String message, HttpStatus status) {
+        this.code    = code;
+        this.message = message;
+        this.status  = status;
+    }
+}

--- a/src/main/java/flab/transtalk/auth/exception/message/JwtExceptionMessages.java
+++ b/src/main/java/flab/transtalk/auth/exception/message/JwtExceptionMessages.java
@@ -1,8 +1,0 @@
-package flab.transtalk.auth.exception.message;
-
-public class JwtExceptionMessages {
-    public static final String TOKEN_EXPIRED     = "JWT 토큰이 만료되었습니다.";
-    public static final String INVALID_SIGNATURE = "JWT 서명이 올바르지 않습니다.";
-    public static final String AUTH_FAILED       = "JWT 인증 처리 중 오류가 발생했습니다.";
-    public static final String USER_NOT_FOUND       = "유효하지 않는 사용자입니다.";
-}

--- a/src/main/java/flab/transtalk/auth/exception/message/JwtExceptionMessages.java
+++ b/src/main/java/flab/transtalk/auth/exception/message/JwtExceptionMessages.java
@@ -1,0 +1,8 @@
+package flab.transtalk.auth.exception.message;
+
+public class JwtExceptionMessages {
+    public static final String TOKEN_EXPIRED     = "JWT 토큰이 만료되었습니다.";
+    public static final String INVALID_SIGNATURE = "JWT 서명이 올바르지 않습니다.";
+    public static final String MALFORMED_TOKEN   = "잘못된 JWT 토큰 형식입니다.";
+    public static final String AUTH_FAILED       = "JWT 인증 처리 중 오류가 발생했습니다.";
+}

--- a/src/main/java/flab/transtalk/auth/exception/message/JwtExceptionMessages.java
+++ b/src/main/java/flab/transtalk/auth/exception/message/JwtExceptionMessages.java
@@ -3,6 +3,6 @@ package flab.transtalk.auth.exception.message;
 public class JwtExceptionMessages {
     public static final String TOKEN_EXPIRED     = "JWT 토큰이 만료되었습니다.";
     public static final String INVALID_SIGNATURE = "JWT 서명이 올바르지 않습니다.";
-    public static final String MALFORMED_TOKEN   = "잘못된 JWT 토큰 형식입니다.";
     public static final String AUTH_FAILED       = "JWT 인증 처리 중 오류가 발생했습니다.";
+    public static final String USER_NOT_FOUND       = "유효하지 않는 사용자입니다.";
 }

--- a/src/main/java/flab/transtalk/auth/repository/AuthAccountRepository.java
+++ b/src/main/java/flab/transtalk/auth/repository/AuthAccountRepository.java
@@ -1,0 +1,11 @@
+package flab.transtalk.auth.repository;
+
+import flab.transtalk.auth.domain.AuthAccount;
+import flab.transtalk.auth.domain.AuthProvider;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface AuthAccountRepository extends JpaRepository<AuthAccount, Long> {
+    Optional<AuthAccount> findByProviderAndProviderId(AuthProvider provider, String providerId);
+}

--- a/src/main/java/flab/transtalk/auth/security/jwt/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/flab/transtalk/auth/security/jwt/JwtAuthenticationEntryPoint.java
@@ -1,0 +1,45 @@
+package flab.transtalk.auth.security.jwt;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import flab.transtalk.auth.exception.JwtAuthenticationException;
+import flab.transtalk.common.dto.res.ApiErrorResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    private final ObjectMapper om;
+
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException ex) throws IOException {
+
+        String code  = "AUTH_FAILED";
+        String message   = "인증 실패";
+
+        if (ex instanceof JwtAuthenticationException jwtEx) {
+            code = jwtEx.getCode();
+            message  = jwtEx.getMessage();
+        }
+
+        log.warn("[AUTH] {} - {}", code, message);
+
+        ApiErrorResponse body = new ApiErrorResponse(code, List.of(message));
+
+        response.setStatus(code.equals("MALFORMED_TOKEN") ? 400 : 401);
+        response.setCharacterEncoding(StandardCharsets.UTF_8.name());
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE + ";charset=UTF-8");
+        om.writeValue(response.getWriter(), body);
+    }
+}

--- a/src/main/java/flab/transtalk/auth/security/jwt/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/flab/transtalk/auth/security/jwt/JwtAuthenticationEntryPoint.java
@@ -29,8 +29,6 @@ public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
         JwtErrorCode ec = (ex instanceof JwtAuthenticationException jae)
                 ? jae.getErrorCode()
                 : JwtErrorCode.AUTH_FAILED;
-        String code  = "AUTH_FAILED";
-        String message   = "인증 실패";
 
         log.warn("[AUTH] {} - {}", ec.getCode(), ec.getMessage());
 

--- a/src/main/java/flab/transtalk/auth/security/jwt/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/flab/transtalk/auth/security/jwt/JwtAuthenticationEntryPoint.java
@@ -2,6 +2,7 @@ package flab.transtalk.auth.security.jwt;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import flab.transtalk.auth.exception.JwtAuthenticationException;
+import flab.transtalk.auth.exception.JwtErrorCode;
 import flab.transtalk.common.dto.res.ApiErrorResponse;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -25,19 +26,20 @@ public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
     @Override
     public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException ex) throws IOException {
 
+        JwtErrorCode ec = (ex instanceof JwtAuthenticationException jae)
+                ? jae.getErrorCode()
+                : JwtErrorCode.AUTH_FAILED;
         String code  = "AUTH_FAILED";
         String message   = "인증 실패";
 
-        if (ex instanceof JwtAuthenticationException jwtEx) {
-            code = jwtEx.getCode();
-            message  = jwtEx.getMessage();
-        }
+        log.warn("[AUTH] {} - {}", ec.getCode(), ec.getMessage());
 
-        log.warn("[AUTH] {} - {}", code, message);
+        ApiErrorResponse body = new ApiErrorResponse(
+                ec.getCode(),
+                List.of(ec.getMessage())
+        );
 
-        ApiErrorResponse body = new ApiErrorResponse(code, List.of(message));
-
-        response.setStatus(code.equals("MALFORMED_TOKEN") ? 400 : 401);
+        response.setStatus(ec.getStatus().value());
         response.setCharacterEncoding(StandardCharsets.UTF_8.name());
         response.setContentType(MediaType.APPLICATION_JSON_VALUE + ";charset=UTF-8");
         om.writeValue(response.getWriter(), body);

--- a/src/main/java/flab/transtalk/auth/security/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/flab/transtalk/auth/security/jwt/JwtAuthenticationFilter.java
@@ -1,7 +1,7 @@
 package flab.transtalk.auth.security.jwt;
 
 import flab.transtalk.auth.exception.JwtAuthenticationException;
-import flab.transtalk.auth.exception.message.JwtExceptionMessages;
+import flab.transtalk.auth.exception.JwtErrorCode;
 import io.jsonwebtoken.*;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
@@ -40,9 +40,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             } catch (JwtAuthenticationException | OAuth2AuthenticationException e) {
                 throw e;
             } catch (RuntimeException e) {
-                throw new JwtAuthenticationException(
-                        "AUTH_FAILED",
-                        JwtExceptionMessages.AUTH_FAILED, e);
+                throw new JwtAuthenticationException(JwtErrorCode.AUTH_FAILED, e);
             }
         }
         filterChain.doFilter(request, response);

--- a/src/main/java/flab/transtalk/auth/security/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/flab/transtalk/auth/security/jwt/JwtAuthenticationFilter.java
@@ -33,8 +33,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         if (header != null && header.startsWith("Bearer ")) {
             String token = header.substring(7);
             try {
-                Jws<Claims> claimsJws = jwtTokenProvider.parseClaims(token);
-                String subject = claimsJws.getBody().getSubject();
+                String subject = jwtTokenProvider.getSubject(token);
                 UserDetails userDetails = userDetailsService.loadUserByUsername(subject);
                 UsernamePasswordAuthenticationToken authToken = new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
                 SecurityContextHolder.getContext().setAuthentication(authToken);

--- a/src/main/java/flab/transtalk/auth/security/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/flab/transtalk/auth/security/jwt/JwtAuthenticationFilter.java
@@ -1,13 +1,15 @@
 package flab.transtalk.auth.security.jwt;
 
-import io.jsonwebtoken.Claims;
-import io.jsonwebtoken.Jws;
+import flab.transtalk.auth.exception.JwtAuthenticationException;
+import flab.transtalk.auth.exception.message.JwtExceptionMessages;
+import io.jsonwebtoken.*;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -15,6 +17,7 @@ import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
@@ -33,8 +36,25 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                 UserDetails userDetails = userDetailsService.loadUserByUsername(userId);
                 UsernamePasswordAuthenticationToken authToken = new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
                 SecurityContextHolder.getContext().setAuthentication(authToken);
-            } catch (RuntimeException ex) {
-                throw new RuntimeException(ex);
+            } catch (ExpiredJwtException e) {
+                throw new JwtAuthenticationException(
+                        "TOKEN_EXPIRED",
+                        JwtExceptionMessages.TOKEN_EXPIRED, e);
+
+            } catch (SignatureException e) {
+                throw new JwtAuthenticationException(
+                        "INVALID_SIGNATURE",
+                        JwtExceptionMessages.INVALID_SIGNATURE, e);
+
+            } catch (MalformedJwtException | UnsupportedJwtException | IllegalArgumentException e) {
+                throw new JwtAuthenticationException(
+                        "MALFORMED_TOKEN",
+                        JwtExceptionMessages.MALFORMED_TOKEN, e);
+
+            } catch (Exception e) {
+                throw new JwtAuthenticationException(
+                        "AUTH_FAILED",
+                        JwtExceptionMessages.AUTH_FAILED, e);
             }
         }
         filterChain.doFilter(request, response);

--- a/src/main/java/flab/transtalk/auth/security/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/flab/transtalk/auth/security/jwt/JwtAuthenticationFilter.java
@@ -15,6 +15,7 @@ import org.springframework.security.authentication.UsernamePasswordAuthenticatio
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 
@@ -37,7 +38,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                 UserDetails userDetails = userDetailsService.loadUserByUsername(subject);
                 UsernamePasswordAuthenticationToken authToken = new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
                 SecurityContextHolder.getContext().setAuthentication(authToken);
-            } catch (JwtAuthenticationException e) {
+            } catch (JwtAuthenticationException | OAuth2AuthenticationException e) {
                 throw e;
             } catch (RuntimeException e) {
                 throw new JwtAuthenticationException(

--- a/src/main/java/flab/transtalk/auth/security/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/flab/transtalk/auth/security/jwt/JwtAuthenticationFilter.java
@@ -10,6 +10,7 @@ import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpHeaders;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -27,7 +28,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
-        String header = request.getHeader("Authorization");
+        String header = request.getHeader(HttpHeaders.AUTHORIZATION);
         if (header != null && header.startsWith("Bearer ")) {
             String token = header.substring(7);
             try {

--- a/src/main/java/flab/transtalk/auth/security/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/flab/transtalk/auth/security/jwt/JwtAuthenticationFilter.java
@@ -1,0 +1,42 @@
+package flab.transtalk.auth.security.jwt;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jws;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private final JwtTokenProvider jwtTokenProvider;
+    private final UserDetailsService userDetailsService;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+        String header = request.getHeader("Authorization");
+        if (header != null && header.startsWith("Bearer ")) {
+            String token = header.substring(7);
+            try {
+                Jws<Claims> claimsJws = jwtTokenProvider.parseClaims(token);
+                String userId = claimsJws.getBody().getSubject();
+                UserDetails userDetails = userDetailsService.loadUserByUsername(userId);
+                UsernamePasswordAuthenticationToken authToken = new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
+                SecurityContextHolder.getContext().setAuthentication(authToken);
+            } catch (RuntimeException ex) {
+                throw new RuntimeException(ex);
+            }
+        }
+        filterChain.doFilter(request, response);
+    }
+}

--- a/src/main/java/flab/transtalk/auth/security/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/flab/transtalk/auth/security/jwt/JwtAuthenticationFilter.java
@@ -37,22 +37,9 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                 UserDetails userDetails = userDetailsService.loadUserByUsername(subject);
                 UsernamePasswordAuthenticationToken authToken = new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
                 SecurityContextHolder.getContext().setAuthentication(authToken);
-            } catch (ExpiredJwtException e) {
-                throw new JwtAuthenticationException(
-                        "TOKEN_EXPIRED",
-                        JwtExceptionMessages.TOKEN_EXPIRED, e);
-
-            } catch (SignatureException e) {
-                throw new JwtAuthenticationException(
-                        "INVALID_SIGNATURE",
-                        JwtExceptionMessages.INVALID_SIGNATURE, e);
-
-            } catch (MalformedJwtException | UnsupportedJwtException | IllegalArgumentException e) {
-                throw new JwtAuthenticationException(
-                        "MALFORMED_TOKEN",
-                        JwtExceptionMessages.MALFORMED_TOKEN, e);
-
-            } catch (Exception e) {
+            } catch (JwtAuthenticationException e) {
+                throw e;
+            } catch (RuntimeException e) {
                 throw new JwtAuthenticationException(
                         "AUTH_FAILED",
                         JwtExceptionMessages.AUTH_FAILED, e);

--- a/src/main/java/flab/transtalk/auth/security/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/flab/transtalk/auth/security/jwt/JwtAuthenticationFilter.java
@@ -33,8 +33,8 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             String token = header.substring(7);
             try {
                 Jws<Claims> claimsJws = jwtTokenProvider.parseClaims(token);
-                String userId = claimsJws.getBody().getSubject();
-                UserDetails userDetails = userDetailsService.loadUserByUsername(userId);
+                String subject = claimsJws.getBody().getSubject();
+                UserDetails userDetails = userDetailsService.loadUserByUsername(subject);
                 UsernamePasswordAuthenticationToken authToken = new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
                 SecurityContextHolder.getContext().setAuthentication(authToken);
             } catch (ExpiredJwtException e) {

--- a/src/main/java/flab/transtalk/auth/security/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/flab/transtalk/auth/security/jwt/JwtAuthenticationFilter.java
@@ -2,7 +2,6 @@ package flab.transtalk.auth.security.jwt;
 
 import flab.transtalk.auth.exception.JwtAuthenticationException;
 import flab.transtalk.auth.exception.JwtErrorCode;
-import io.jsonwebtoken.*;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;

--- a/src/main/java/flab/transtalk/auth/security/jwt/JwtTokenProvider.java
+++ b/src/main/java/flab/transtalk/auth/security/jwt/JwtTokenProvider.java
@@ -1,10 +1,13 @@
 package flab.transtalk.auth.security.jwt;
+import flab.transtalk.auth.exception.JwtAuthenticationException;
+import flab.transtalk.auth.exception.message.JwtExceptionMessages;
 import io.jsonwebtoken.*;
 import io.jsonwebtoken.security.Keys;
 import jakarta.annotation.PostConstruct;
 
 import java.nio.charset.StandardCharsets;
 import java.util.Date;
+import java.util.Map;
 import javax.crypto.SecretKey;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
@@ -40,9 +43,19 @@ public class JwtTokenProvider {
     }
 
     public Jws<Claims> parseClaims(String token) {
-        return Jwts.parserBuilder()
-                .setSigningKey(key)
-                .build()
-                .parseClaimsJws(token);
+        try {
+            return Jwts.parserBuilder()
+                    .setSigningKey(key)
+                    .build()
+                    .parseClaimsJws(token);
+        } catch (ExpiredJwtException e) {
+            throw new JwtAuthenticationException(
+                    "TOKEN_EXPIRED",
+                    JwtExceptionMessages.TOKEN_EXPIRED, e);
+        } catch (JwtException | IllegalArgumentException e) {
+            throw new JwtAuthenticationException(
+                    "INVALID_SIGNATURE",
+                    JwtExceptionMessages.INVALID_SIGNATURE, e);
+        }
     }
 }

--- a/src/main/java/flab/transtalk/auth/security/jwt/JwtTokenProvider.java
+++ b/src/main/java/flab/transtalk/auth/security/jwt/JwtTokenProvider.java
@@ -46,7 +46,11 @@ public class JwtTokenProvider {
                 .compact();
     }
 
-    public Jws<Claims> parseClaims(String token) {
+    public String getSubject(String token) {
+        return parseClaims(token).getBody().getSubject();
+    }
+
+    private Jws<Claims> parseClaims(String token) {
         try {
             return Jwts.parserBuilder()
                     .setSigningKey(key)

--- a/src/main/java/flab/transtalk/auth/security/jwt/JwtTokenProvider.java
+++ b/src/main/java/flab/transtalk/auth/security/jwt/JwtTokenProvider.java
@@ -1,6 +1,6 @@
 package flab.transtalk.auth.security.jwt;
 import flab.transtalk.auth.exception.JwtAuthenticationException;
-import flab.transtalk.auth.exception.message.JwtExceptionMessages;
+import flab.transtalk.auth.exception.JwtErrorCode;
 import io.jsonwebtoken.*;
 import io.jsonwebtoken.security.Keys;
 import jakarta.annotation.PostConstruct;
@@ -57,13 +57,11 @@ public class JwtTokenProvider {
                     .build()
                     .parseClaimsJws(token);
         } catch (ExpiredJwtException e) {
-            throw new JwtAuthenticationException(
-                    "TOKEN_EXPIRED",
-                    JwtExceptionMessages.TOKEN_EXPIRED, e);
-        } catch (JwtException | IllegalArgumentException e) {
-            throw new JwtAuthenticationException(
-                    "INVALID_SIGNATURE",
-                    JwtExceptionMessages.INVALID_SIGNATURE, e);
+            throw new JwtAuthenticationException(JwtErrorCode.TOKEN_EXPIRED, e);
+        } catch (MalformedJwtException | UnsupportedJwtException | IllegalArgumentException e) {
+            throw new JwtAuthenticationException(JwtErrorCode.MALFORMED_TOKEN, e);
+        } catch (SignatureException e) {
+            throw new JwtAuthenticationException(JwtErrorCode.INVALID_SIGNATURE, e);
         }
     }
 }

--- a/src/main/java/flab/transtalk/auth/security/jwt/JwtTokenProvider.java
+++ b/src/main/java/flab/transtalk/auth/security/jwt/JwtTokenProvider.java
@@ -25,10 +25,10 @@ public class JwtTokenProvider {
         this.key = Keys.hmacShaKeyFor(secret.getBytes());
     }
 
-    public String createToken(String email, String role) {
+    public String createToken(String subject, String role) {
         Date now = new Date();
         return Jwts.builder()
-                .setSubject(email)
+                .setSubject(subject)
                 .claim("role", role)
                 .setIssuedAt(now)
                 .setExpiration(new Date(now.getTime() + expiration))

--- a/src/main/java/flab/transtalk/auth/security/jwt/JwtTokenProvider.java
+++ b/src/main/java/flab/transtalk/auth/security/jwt/JwtTokenProvider.java
@@ -1,0 +1,45 @@
+package flab.transtalk.auth.security.jwt;
+import io.jsonwebtoken.*;
+import io.jsonwebtoken.security.Keys;
+import jakarta.annotation.PostConstruct;
+import java.util.Date;
+import javax.crypto.SecretKey;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class JwtTokenProvider {
+
+    @Value("${jwt.secret}")
+    private String secret;
+
+    @Value("${jwt.expiration}")
+    private long expiration;
+
+    private SecretKey key;
+
+    @PostConstruct
+    private void init() {
+        this.key = Keys.hmacShaKeyFor(secret.getBytes());
+    }
+
+    public String createToken(String email, String role) {
+        Date now = new Date();
+        return Jwts.builder()
+                .setSubject(email)
+                .claim("role", role)
+                .setIssuedAt(now)
+                .setExpiration(new Date(now.getTime() + expiration))
+                .signWith(key, SignatureAlgorithm.HS256)
+                .compact();
+    }
+
+    public Jws<Claims> parseClaims(String token) {
+        return Jwts.parserBuilder()
+                .setSigningKey(key)
+                .build()
+                .parseClaimsJws(token);
+    }
+}

--- a/src/main/java/flab/transtalk/auth/security/jwt/JwtTokenProvider.java
+++ b/src/main/java/flab/transtalk/auth/security/jwt/JwtTokenProvider.java
@@ -32,10 +32,14 @@ public class JwtTokenProvider {
     }
 
     public String createToken(String subject, String role) {
+        return createToken(subject, Map.of("role", role));
+    }
+
+    public String createToken(String subject, Map<String, Object> claims) {
         Date now = new Date();
         return Jwts.builder()
                 .setSubject(subject)
-                .claim("role", role)
+                .addClaims(claims)
                 .setIssuedAt(now)
                 .setExpiration(new Date(now.getTime() + expiration))
                 .signWith(key, SignatureAlgorithm.HS256)

--- a/src/main/java/flab/transtalk/auth/security/jwt/JwtTokenProvider.java
+++ b/src/main/java/flab/transtalk/auth/security/jwt/JwtTokenProvider.java
@@ -2,6 +2,8 @@ package flab.transtalk.auth.security.jwt;
 import io.jsonwebtoken.*;
 import io.jsonwebtoken.security.Keys;
 import jakarta.annotation.PostConstruct;
+
+import java.nio.charset.StandardCharsets;
 import java.util.Date;
 import javax.crypto.SecretKey;
 import lombok.RequiredArgsConstructor;
@@ -22,7 +24,8 @@ public class JwtTokenProvider {
 
     @PostConstruct
     private void init() {
-        this.key = Keys.hmacShaKeyFor(secret.getBytes());
+
+        this.key = Keys.hmacShaKeyFor(secret.getBytes(StandardCharsets.UTF_8));
     }
 
     public String createToken(String subject, String role) {

--- a/src/main/java/flab/transtalk/auth/security/oauth/OAuth2SuccessHandler.java
+++ b/src/main/java/flab/transtalk/auth/security/oauth/OAuth2SuccessHandler.java
@@ -1,6 +1,7 @@
 package flab.transtalk.auth.security.oauth;
 import flab.transtalk.auth.domain.AuthProvider;
 import flab.transtalk.auth.domain.ProviderInfo;
+import flab.transtalk.auth.exception.message.JwtExceptionMessages;
 import flab.transtalk.auth.security.jwt.JwtTokenProvider;
 import flab.transtalk.user.domain.User;
 import flab.transtalk.user.repository.UserRepository;
@@ -9,6 +10,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
 import org.springframework.stereotype.Component;
@@ -40,7 +42,7 @@ public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
 
         User user = userRepository
                 .findByProviderAndProviderId(providerInfo.getProvider(), providerInfo.getProviderId())
-                .orElseThrow();
+                .orElseThrow(() -> new OAuth2AuthenticationException(JwtExceptionMessages.AUTH_FAILED));
 
         String subject = providerInfo.toSubject();
         String jwt = jwtTokenProvider.createToken(subject, DEFAULT_ROLE);

--- a/src/main/java/flab/transtalk/auth/security/oauth/OAuth2SuccessHandler.java
+++ b/src/main/java/flab/transtalk/auth/security/oauth/OAuth2SuccessHandler.java
@@ -1,0 +1,62 @@
+package flab.transtalk.auth.security.oauth;
+import flab.transtalk.auth.domain.AuthProvider;
+import flab.transtalk.auth.security.jwt.JwtTokenProvider;
+import flab.transtalk.user.domain.User;
+import flab.transtalk.user.repository.UserRepository;
+import java.io.IOException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
+import org.springframework.stereotype.Component;
+import org.springframework.web.util.UriComponentsBuilder;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+@Component
+@RequiredArgsConstructor
+public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
+
+    private final JwtTokenProvider jwtTokenProvider;
+    private final UserRepository userRepository;
+
+    @Value("${spring.security.oauth2.frontend.redirect-uri}")
+    private String redirectUri;
+
+    private static final String DEFAULT_ROLE = "ROLE_USER";
+
+    @Override
+    public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException, ServletException {
+        OAuth2AuthenticationToken authToken = (OAuth2AuthenticationToken) authentication;
+        String registrationId = authToken.getAuthorizedClientRegistrationId();
+
+        AuthProvider provider;
+        String nameAttributeKey;
+        switch (registrationId) {
+            case "google" -> {
+                provider = AuthProvider.GOOGLE;
+                nameAttributeKey = "sub";
+            }
+            default -> throw new IllegalStateException("미지원 소셜: " + registrationId);
+        }
+
+        OAuth2User oAuth2User = (OAuth2User) authentication.getPrincipal();
+        String providerId = (String) oAuth2User.getAttributes().get(nameAttributeKey);
+
+        User user = userRepository
+                .findByProviderAndProviderId(provider, providerId)
+                .orElseThrow();
+
+        String subject = user.getProvider() + ":" + user.getProviderId();
+        String jwt = jwtTokenProvider.createToken(subject, DEFAULT_ROLE);
+
+        String redirectUrl = UriComponentsBuilder.fromUriString(this.redirectUri)
+                .queryParam("token", jwt)
+                .build().toUriString();
+
+        getRedirectStrategy().sendRedirect(request, response, redirectUrl);
+    }
+}

--- a/src/main/java/flab/transtalk/auth/security/oauth/OAuth2SuccessHandler.java
+++ b/src/main/java/flab/transtalk/auth/security/oauth/OAuth2SuccessHandler.java
@@ -38,13 +38,12 @@ public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
         String registrationId = authToken.getAuthorizedClientRegistrationId();
 
         ProviderInfo providerInfo = ProviderInfo.fromOAuth2User(registrationId, oAuth2User);
-        String nameAttributeKey = providerInfo.getNameAttributeKey();
 
         User user = userRepository
                 .findByProviderAndProviderId(providerInfo.getProvider(), providerInfo.getProviderId())
                 .orElseThrow(() -> new OAuth2AuthenticationException(JwtExceptionMessages.AUTH_FAILED));
 
-        String subject = providerInfo.toSubject();
+        String subject = user.getExternalId();
         String jwt = jwtTokenProvider.createToken(subject, DEFAULT_ROLE);
 
         String redirectUrl = UriComponentsBuilder.fromUriString(this.redirectUri)

--- a/src/main/java/flab/transtalk/auth/security/principal/CustomUserDetails.java
+++ b/src/main/java/flab/transtalk/auth/security/principal/CustomUserDetails.java
@@ -4,7 +4,6 @@ import lombok.Builder;
 import lombok.Value;
 import org.springframework.security.core.userdetails.UserDetails;
 import java.util.Collection;
-import lombok.Getter;
 import org.springframework.security.core.GrantedAuthority;
 
 @Value

--- a/src/main/java/flab/transtalk/auth/security/principal/CustomUserDetails.java
+++ b/src/main/java/flab/transtalk/auth/security/principal/CustomUserDetails.java
@@ -1,0 +1,35 @@
+package flab.transtalk.auth.security.principal;
+
+import lombok.Builder;
+import lombok.Value;
+import org.springframework.security.core.userdetails.UserDetails;
+import java.util.Collection;
+import lombok.Getter;
+import org.springframework.security.core.GrantedAuthority;
+
+@Value
+@Builder
+public class CustomUserDetails implements UserDetails {
+
+    private final Long userId;                          // userId
+    private final String username;                      // JWT subject
+    private final Collection<? extends GrantedAuthority> authorities;
+
+    public CustomUserDetails(Long userId, String username, Collection<? extends GrantedAuthority> authorities) {
+        this.userId = userId;
+        this.username = username;
+        this.authorities = authorities;
+    }
+
+    public Long getUserId(){
+        return userId;
+    }
+
+    @Override public Collection<? extends GrantedAuthority> getAuthorities() { return authorities; }
+    @Override public String getPassword() { return ""; }      // 소셜 로그인
+    @Override public String getUsername() { return username; }
+    @Override public boolean isAccountNonExpired() { return true; }
+    @Override public boolean isAccountNonLocked() { return true; }
+    @Override public boolean isCredentialsNonExpired() { return true; }
+    @Override public boolean isEnabled() { return true; }
+}

--- a/src/main/java/flab/transtalk/auth/service/CustomOAuth2UserService.java
+++ b/src/main/java/flab/transtalk/auth/service/CustomOAuth2UserService.java
@@ -1,9 +1,8 @@
 package flab.transtalk.auth.service;
 import java.util.Collections;
+import java.util.Map;
 
-import flab.transtalk.auth.domain.AuthProvider;
 import flab.transtalk.auth.domain.ProviderInfo;
-import flab.transtalk.auth.exception.message.JwtExceptionMessages;
 import flab.transtalk.user.domain.User;
 import flab.transtalk.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
@@ -25,12 +24,10 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
     @Override
     public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
         OAuth2User oAuth2User = super.loadUser(userRequest);
-
         String registrationId = userRequest.getClientRegistration().getRegistrationId();
 
         ProviderInfo providerInfo = ProviderInfo.fromOAuth2User(registrationId, oAuth2User);
         String nameAttributeKey = providerInfo.getNameAttributeKey();
-
         String email = (String) oAuth2User.getAttribute("email");
         String name = (String) oAuth2User.getAttribute("name");
 
@@ -43,9 +40,13 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
                         .name(name)
                         .build()));
 
+        Map<String, Object> exposed = Map.of(
+                nameAttributeKey, providerInfo.getProviderId()
+        );
+
         return new DefaultOAuth2User(
                 Collections.singleton(new SimpleGrantedAuthority(DEFAULT_ROLE)),
-                oAuth2User.getAttributes(),
+                exposed,
                 nameAttributeKey);
     }
 }

--- a/src/main/java/flab/transtalk/auth/service/CustomOAuth2UserService.java
+++ b/src/main/java/flab/transtalk/auth/service/CustomOAuth2UserService.java
@@ -2,6 +2,7 @@ package flab.transtalk.auth.service;
 import java.util.Collections;
 
 import flab.transtalk.auth.domain.AuthProvider;
+import flab.transtalk.auth.exception.message.JwtExceptionMessages;
 import flab.transtalk.user.domain.User;
 import flab.transtalk.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
@@ -34,7 +35,7 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
                 providerId = (String) oAuth2User.getAttribute("sub");
                 nameAttributeKey = "sub";
             }
-            default -> throw new OAuth2AuthenticationException("Unsupported provider: " + registrationId);
+            default -> throw new OAuth2AuthenticationException(JwtExceptionMessages.AUTH_FAILED);
         }
         String email = (String) oAuth2User.getAttribute("email");
         String name = (String) oAuth2User.getAttribute("name");

--- a/src/main/java/flab/transtalk/auth/service/CustomOAuth2UserService.java
+++ b/src/main/java/flab/transtalk/auth/service/CustomOAuth2UserService.java
@@ -1,0 +1,56 @@
+package flab.transtalk.auth.service;
+import java.util.Collections;
+
+import flab.transtalk.auth.domain.AuthProvider;
+import flab.transtalk.user.domain.User;
+import flab.transtalk.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class CustomOAuth2UserService extends DefaultOAuth2UserService {
+    private final UserRepository userRepository;
+
+    private static final String DEFAULT_ROLE = "ROLE_USER";
+
+    @Override
+    public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
+        OAuth2User oAuth2User = super.loadUser(userRequest);
+
+        String registrationId = userRequest.getClientRegistration().getRegistrationId();
+        String providerId;
+        String nameAttributeKey;
+        AuthProvider provider;
+        switch (registrationId.toLowerCase()) {
+            case "google" -> {
+                provider = AuthProvider.GOOGLE;
+                providerId = (String) oAuth2User.getAttribute("sub");
+                nameAttributeKey = "sub";
+            }
+            default -> throw new OAuth2AuthenticationException("Unsupported provider: " + registrationId);
+        }
+        String email = (String) oAuth2User.getAttribute("email");
+        String name = (String) oAuth2User.getAttribute("name");
+
+        User user = userRepository
+                .findByProviderAndProviderId(provider, providerId)
+                .orElseGet(() -> userRepository.save(User.builder()
+                        .provider(provider)
+                        .providerId(providerId)
+                        .email(email)
+                        .name(name)
+                        .build()));
+
+        return new DefaultOAuth2User(
+                Collections.singleton(new SimpleGrantedAuthority(DEFAULT_ROLE)),
+                oAuth2User.getAttributes(),
+                nameAttributeKey);
+    }
+}

--- a/src/main/java/flab/transtalk/auth/service/CustomOAuth2UserService.java
+++ b/src/main/java/flab/transtalk/auth/service/CustomOAuth2UserService.java
@@ -2,7 +2,9 @@ package flab.transtalk.auth.service;
 import java.util.Collections;
 import java.util.Map;
 
+import flab.transtalk.auth.domain.AuthAccount;
 import flab.transtalk.auth.domain.ProviderInfo;
+import flab.transtalk.auth.repository.AuthAccountRepository;
 import flab.transtalk.user.domain.User;
 import flab.transtalk.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
@@ -13,15 +15,18 @@ import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
 import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
 public class CustomOAuth2UserService extends DefaultOAuth2UserService {
     private final UserRepository userRepository;
+    private final AuthAccountRepository authAccountRepository;
 
     private static final String DEFAULT_ROLE = "ROLE_USER";
 
     @Override
+    @Transactional
     public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
         OAuth2User oAuth2User = super.loadUser(userRequest);
         String registrationId = userRequest.getClientRegistration().getRegistrationId();
@@ -31,14 +36,20 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
         String email = (String) oAuth2User.getAttribute("email");
         String name = (String) oAuth2User.getAttribute("name");
 
-        User user = userRepository
+        authAccountRepository
                 .findByProviderAndProviderId(providerInfo.getProvider(), providerInfo.getProviderId())
-                .orElseGet(() -> userRepository.save(User.builder()
-                        .provider(providerInfo.getProvider())
-                        .providerId(providerInfo.getProviderId())
-                        .email(email)
-                        .name(name)
-                        .build()));
+                .orElseGet(() -> {
+                    User user = userRepository.save(User.builder()
+                            .name(name)
+                            .email(email)
+                            .birthDate(null)
+                            .build());
+                    return authAccountRepository.save(AuthAccount.builder()
+                            .provider(providerInfo.getProvider())
+                            .providerId(providerInfo.getProviderId())
+                            .user(user)                                    // Δ
+                            .build());
+                });
 
         Map<String, Object> exposed = Map.of(
                 nameAttributeKey, providerInfo.getProviderId()

--- a/src/main/java/flab/transtalk/auth/service/CustomUserDetailsService.java
+++ b/src/main/java/flab/transtalk/auth/service/CustomUserDetailsService.java
@@ -1,14 +1,13 @@
 package flab.transtalk.auth.service;
 
 import flab.transtalk.auth.exception.JwtAuthenticationException;
-import flab.transtalk.auth.exception.message.JwtExceptionMessages;
+import flab.transtalk.auth.exception.JwtErrorCode;
 import flab.transtalk.auth.security.principal.CustomUserDetails;
 import flab.transtalk.user.domain.User;
 import flab.transtalk.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.*;
-import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -25,7 +24,7 @@ public class CustomUserDetailsService implements UserDetailsService {
     @Transactional(readOnly = true)
     public UserDetails loadUserByUsername(String externalId) throws UsernameNotFoundException {
         User user = userRepository.findByExternalId(externalId)
-                .orElseThrow(() -> new UsernameNotFoundException(JwtExceptionMessages.USER_NOT_FOUND));
+                .orElseThrow(() -> new JwtAuthenticationException(JwtErrorCode.USER_NOT_FOUND, null));
 
         return CustomUserDetails.builder()
                 .userId(user.getId())

--- a/src/main/java/flab/transtalk/auth/service/CustomUserDetailsService.java
+++ b/src/main/java/flab/transtalk/auth/service/CustomUserDetailsService.java
@@ -1,5 +1,7 @@
 package flab.transtalk.auth.service;
 
+import flab.transtalk.auth.domain.ProviderInfo;
+import flab.transtalk.auth.exception.message.JwtExceptionMessages;
 import flab.transtalk.auth.security.principal.CustomUserDetails;
 import flab.transtalk.auth.domain.AuthProvider;
 import flab.transtalk.user.domain.User;
@@ -7,6 +9,7 @@ import flab.transtalk.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.*;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -21,24 +24,15 @@ public class CustomUserDetailsService implements UserDetailsService {
 
     @Override
     @Transactional(readOnly = true)
-    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
-        if (!username.contains(":")) {
-            throw new UsernameNotFoundException("Invalid token subject: " + username);
-        }
-        String[] parts = username.split(":", 2);
-        AuthProvider provider;
-        try {
-            provider = AuthProvider.valueOf(parts[0]);
-        } catch (IllegalArgumentException e) {
-            throw new UsernameNotFoundException("Unsupported provider: " + parts[0]);
-        }
+    public UserDetails loadUserByUsername(String subject) throws UsernameNotFoundException {
+        ProviderInfo providerInfo = ProviderInfo.fromSubject(subject);
 
         User user = userRepository
-                .findByProviderAndProviderId(provider, parts[1])
-                .orElseThrow(() -> new UsernameNotFoundException("User not found: " + username));
+                .findByProviderAndProviderId(providerInfo.getProvider(), providerInfo.getProviderId())
+                .orElseThrow(() -> new UsernameNotFoundException("User not found: " + subject));
 
         // JWT subject를 username으로 사용
-        return toUserDetails(user.getId(), username);
+        return toUserDetails(user.getId(), subject);
     }
 
     private UserDetails toUserDetails(long userId, String username) {

--- a/src/main/java/flab/transtalk/auth/service/CustomUserDetailsService.java
+++ b/src/main/java/flab/transtalk/auth/service/CustomUserDetailsService.java
@@ -1,0 +1,51 @@
+package flab.transtalk.auth.service;
+
+import flab.transtalk.auth.security.principal.CustomUserDetails;
+import flab.transtalk.auth.domain.AuthProvider;
+import flab.transtalk.user.domain.User;
+import flab.transtalk.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.*;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Collections;
+
+@Service
+@RequiredArgsConstructor
+public class CustomUserDetailsService implements UserDetailsService {
+
+    private final UserRepository userRepository;
+    private static final String DEFAULT_ROLE = "ROLE_USER";
+
+    @Override
+    @Transactional(readOnly = true)
+    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+        if (!username.contains(":")) {
+            throw new UsernameNotFoundException("Invalid token subject: " + username);
+        }
+        String[] parts = username.split(":", 2);
+        AuthProvider provider;
+        try {
+            provider = AuthProvider.valueOf(parts[0]);
+        } catch (IllegalArgumentException e) {
+            throw new UsernameNotFoundException("Unsupported provider: " + parts[0]);
+        }
+
+        User user = userRepository
+                .findByProviderAndProviderId(provider, parts[1])
+                .orElseThrow(() -> new UsernameNotFoundException("User not found: " + username));
+
+        // JWT subject를 username으로 사용
+        return toUserDetails(user.getId(), username);
+    }
+
+    private UserDetails toUserDetails(long userId, String username) {
+        return CustomUserDetails.builder()
+                .userId(userId)
+                .username(username)
+                .authorities(Collections.singleton(new SimpleGrantedAuthority(DEFAULT_ROLE)))
+                .build();
+    }
+}

--- a/src/main/java/flab/transtalk/common/exception/message/ExceptionMessages.java
+++ b/src/main/java/flab/transtalk/common/exception/message/ExceptionMessages.java
@@ -2,7 +2,6 @@ package flab.transtalk.common.exception.message;
 
 public class ExceptionMessages {
     // NotFoundException
-    public static final String NO_USER_FOUND = "발견된 사용자가 없습니다.";
     public static final String USER_NOT_FOUND_IN_PARTICIPANTS = "존재하지 않는(또는 중복된) 참가자가 포함되어 있습니다.";
     public static final String USER_NOT_FOUND = "존재하지 않는 사용자입니다.";
     public static final String PROFILE_NOT_FOUND = "존재하지 않는 프로필입니다.";

--- a/src/main/java/flab/transtalk/config/ServiceConfigConstants.java
+++ b/src/main/java/flab/transtalk/config/ServiceConfigConstants.java
@@ -7,4 +7,5 @@ import lombok.NoArgsConstructor;
 public class ServiceConfigConstants {
     public static final String S3_POST_IMAGE_FOLDER_NAME = "posts/";
     public static final long PRESIGNED_URL_DURATION_HOUR = 6;
+    public static final int MATCHING_USERS_MAX_NUMBER = 4;
 }

--- a/src/main/java/flab/transtalk/user/controller/UserController.java
+++ b/src/main/java/flab/transtalk/user/controller/UserController.java
@@ -1,6 +1,7 @@
 package flab.transtalk.user.controller;
 
 import flab.transtalk.user.dto.req.UserCreateRequestDto;
+import flab.transtalk.user.dto.res.UserListResponseDto;
 import flab.transtalk.user.dto.res.UserResponseDto;
 import flab.transtalk.user.service.user.UserService;
 import jakarta.validation.Valid;
@@ -28,7 +29,11 @@ public class UserController {
 
     // 주어진 사용자 제외, 무작위 사용자 호출
     @GetMapping("/matching/{currentUserId}")
-    public ResponseEntity<UserResponseDto> getMatchingUser(@PathVariable Long currentUserId){
-        return ResponseEntity.status(HttpStatus.OK).body(userService.getUserExcept(currentUserId));
+    public ResponseEntity<UserListResponseDto> getMatchingUsers(@PathVariable Long currentUserId){
+        return ResponseEntity.status(HttpStatus.OK).body(
+                UserListResponseDto.builder()
+                        .users(userService.getUsersExcept(currentUserId))
+                        .build()
+        );
     }
 }

--- a/src/main/java/flab/transtalk/user/domain/User.java
+++ b/src/main/java/flab/transtalk/user/domain/User.java
@@ -1,5 +1,6 @@
 package flab.transtalk.user.domain;
 
+import flab.transtalk.auth.domain.AuthProvider;
 import flab.transtalk.translation.domain.ChatRoomUser;
 import jakarta.persistence.*;
 import java.time.LocalDate;
@@ -9,7 +10,12 @@ import java.util.List;
 import lombok.*;
 
 @Entity
-@Table(name = "users")
+@Table(
+        name = "users",
+        uniqueConstraints = {
+                @UniqueConstraint(name = "uk_provider_pid", columnNames = {"provider", "provider_id"}),
+        }
+)
 @Getter
 @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -26,6 +32,16 @@ public class User {
 
     @Column(name = "name", length = 50)
     private String name;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private AuthProvider provider;
+
+    @Column(name = "provider_id", nullable = false)
+    private String providerId;
+
+    @Column(name = "email")
+    private String email;
 
     @Column(name = "birth_date", columnDefinition = "DATE")
     private LocalDate birthDate;

--- a/src/main/java/flab/transtalk/user/domain/User.java
+++ b/src/main/java/flab/transtalk/user/domain/User.java
@@ -1,5 +1,6 @@
 package flab.transtalk.user.domain;
 
+import flab.transtalk.auth.domain.AuthAccount;
 import flab.transtalk.auth.domain.AuthProvider;
 import flab.transtalk.translation.domain.ChatRoomUser;
 import jakarta.persistence.*;
@@ -33,21 +34,14 @@ public class User {
     @Column(name = "name", length = 50)
     private String name;
 
-    @Enumerated(EnumType.STRING)
-    @Column(nullable = false)
-    private AuthProvider provider;
-
-    @Column(name = "provider_id", nullable = false)
-    private String providerId;
-
-    @Column(name = "external_id", unique = true, nullable = false, length = 36)
-    private String externalId;
-
     @Column(name = "email")
     private String email;
 
     @Column(name = "birth_date", columnDefinition = "DATE")
     private LocalDate birthDate;
+
+    @Column(name = "external_id", unique = true, nullable = false, length = 36)
+    private String externalId;
 
     @OneToOne(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.EAGER)
     private Profile profile;
@@ -55,11 +49,12 @@ public class User {
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
     private List<ChatRoomUser> chatRoomUsers = new ArrayList<>();
 
+    @OneToOne(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
+    private AuthAccount authAccount;
+
     @Builder
-    private User(String name, AuthProvider provider, String providerId, String email, LocalDate birthDate) {
+    private User(String name, String email, LocalDate birthDate) {
         this.name       = name;
-        this.provider   = provider;
-        this.providerId = providerId;
         this.email      = email;
         this.birthDate  = birthDate;
         // externalId 는 null -> @PrePersist에서 자동 생성

--- a/src/main/java/flab/transtalk/user/dto/res/UserListResponseDto.java
+++ b/src/main/java/flab/transtalk/user/dto/res/UserListResponseDto.java
@@ -1,0 +1,12 @@
+package flab.transtalk.user.dto.res;
+
+import lombok.Builder;
+import lombok.Value;
+
+import java.util.List;
+
+@Value
+@Builder
+public class UserListResponseDto {
+    private List<UserResponseDto> users;
+}

--- a/src/main/java/flab/transtalk/user/repository/UserRepository.java
+++ b/src/main/java/flab/transtalk/user/repository/UserRepository.java
@@ -1,6 +1,5 @@
 package flab.transtalk.user.repository;
 
-import flab.transtalk.auth.domain.AuthProvider;
 import flab.transtalk.user.domain.User;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;

--- a/src/main/java/flab/transtalk/user/repository/UserRepository.java
+++ b/src/main/java/flab/transtalk/user/repository/UserRepository.java
@@ -17,6 +17,5 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
     List<User> findAllByIdIn(List<Long> ids);
 
-    Optional<User> findByProviderAndProviderId(AuthProvider provider, String providerId);
     Optional<User> findByExternalId(String externalId);
 }

--- a/src/main/java/flab/transtalk/user/repository/UserRepository.java
+++ b/src/main/java/flab/transtalk/user/repository/UserRepository.java
@@ -1,15 +1,19 @@
 package flab.transtalk.user.repository;
 
+import flab.transtalk.auth.domain.AuthProvider;
 import flab.transtalk.user.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<User, Long> {
     @Query("SELECT u FROM User u WHERE u.id <> :userId ORDER BY function('RAND')")
     User findRandomUserExcept(@Param("userId") Long userId);
 
     List<User> findAllByIdIn(List<Long> ids);
+
+    Optional<User> findByProviderAndProviderId(AuthProvider provider, String providerId);
 }

--- a/src/main/java/flab/transtalk/user/repository/UserRepository.java
+++ b/src/main/java/flab/transtalk/user/repository/UserRepository.java
@@ -2,6 +2,7 @@ package flab.transtalk.user.repository;
 
 import flab.transtalk.auth.domain.AuthProvider;
 import flab.transtalk.user.domain.User;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -10,8 +11,10 @@ import java.util.List;
 import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<User, Long> {
-    @Query("SELECT u FROM User u WHERE u.id <> :userId ORDER BY function('RAND')")
-    User findRandomUserExcept(@Param("userId") Long userId);
+    @Query("SELECT u FROM User u WHERE u.id <> :userId")
+    List<User> findAllExcept(@Param("userId") Long userId, Pageable pageable);
+
+    long countByIdNot(Long userId);
 
     List<User> findAllByIdIn(List<Long> ids);
 

--- a/src/main/java/flab/transtalk/user/repository/UserRepository.java
+++ b/src/main/java/flab/transtalk/user/repository/UserRepository.java
@@ -13,10 +13,10 @@ import java.util.Optional;
 public interface UserRepository extends JpaRepository<User, Long> {
     @Query("SELECT u FROM User u WHERE u.id <> :userId")
     List<User> findAllExcept(@Param("userId") Long userId, Pageable pageable);
-
     long countByIdNot(Long userId);
 
     List<User> findAllByIdIn(List<Long> ids);
 
     Optional<User> findByProviderAndProviderId(AuthProvider provider, String providerId);
+    Optional<User> findByExternalId(String externalId);
 }

--- a/src/main/java/flab/transtalk/user/service/user/UserMatchingService.java
+++ b/src/main/java/flab/transtalk/user/service/user/UserMatchingService.java
@@ -31,6 +31,6 @@ public class UserMatchingService {
         if (users==null){
             return List.of();
         }
-        return users.stream().map(user->UserResponseDto.from(user)).collect(Collectors.toList());
+        return users.stream().map(UserResponseDto::from).toList();
     }
 }

--- a/src/main/java/flab/transtalk/user/service/user/UserMatchingService.java
+++ b/src/main/java/flab/transtalk/user/service/user/UserMatchingService.java
@@ -1,12 +1,17 @@
 package flab.transtalk.user.service.user;
 
-import flab.transtalk.common.exception.NotFoundException;
-import flab.transtalk.common.exception.message.ExceptionMessages;
 import flab.transtalk.user.domain.User;
 import flab.transtalk.user.dto.res.UserResponseDto;
 import flab.transtalk.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Random;
+import java.util.stream.Collectors;
+
+import flab.transtalk.config.ServiceConfigConstants;
 
 @Service
 @RequiredArgsConstructor
@@ -14,14 +19,18 @@ public class UserMatchingService {
 
     private final UserRepository userRepository;
 
-    public UserResponseDto getUserExcept(Long currentUserId) {
-        User user = userRepository.findRandomUserExcept(currentUserId);
-        if (user == null){
-            throw new NotFoundException(
-                    ExceptionMessages.NO_USER_FOUND,
-                    currentUserId.toString()
-            );
+    public List<UserResponseDto> getUsersExcept(Long currentUserId) {
+        long total = userRepository.countByIdNot(currentUserId);
+        if (total==0l){
+            return List.of();
         }
-        return UserResponseDto.from(user);
+        int maxOffset = (int) Math.max(total - ServiceConfigConstants.MATCHING_USERS_MAX_NUMBER, 0);
+        int randomOffset = new Random().nextInt(maxOffset + 1);
+        PageRequest pageRequest = PageRequest.of(randomOffset, ServiceConfigConstants.MATCHING_USERS_MAX_NUMBER);
+        List<User> users = userRepository.findAllExcept(currentUserId, pageRequest);
+        if (users==null){
+            return List.of();
+        }
+        return users.stream().map(user->UserResponseDto.from(user)).collect(Collectors.toList());
     }
 }

--- a/src/main/java/flab/transtalk/user/service/user/UserMatchingService.java
+++ b/src/main/java/flab/transtalk/user/service/user/UserMatchingService.java
@@ -9,7 +9,6 @@ import org.springframework.stereotype.Service;
 
 import java.util.List;
 import java.util.Random;
-import java.util.stream.Collectors;
 
 import flab.transtalk.config.ServiceConfigConstants;
 

--- a/src/main/java/flab/transtalk/user/service/user/UserMatchingService.java
+++ b/src/main/java/flab/transtalk/user/service/user/UserMatchingService.java
@@ -18,14 +18,14 @@ import flab.transtalk.config.ServiceConfigConstants;
 public class UserMatchingService {
 
     private final UserRepository userRepository;
-
+    private static final Random RANDOM = new Random();
     public List<UserResponseDto> getUsersExcept(Long currentUserId) {
         long total = userRepository.countByIdNot(currentUserId);
         if (total==0l){
             return List.of();
         }
         int maxOffset = (int) Math.max(total - ServiceConfigConstants.MATCHING_USERS_MAX_NUMBER, 0);
-        int randomOffset = new Random().nextInt(maxOffset + 1);
+        int randomOffset = RANDOM.nextInt(maxOffset + 1);
         PageRequest pageRequest = PageRequest.of(randomOffset, ServiceConfigConstants.MATCHING_USERS_MAX_NUMBER);
         List<User> users = userRepository.findAllExcept(currentUserId, pageRequest);
         if (users==null){

--- a/src/main/java/flab/transtalk/user/service/user/UserService.java
+++ b/src/main/java/flab/transtalk/user/service/user/UserService.java
@@ -9,6 +9,7 @@ import flab.transtalk.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.util.List;
 import java.util.Optional;
 
 @Service
@@ -23,8 +24,8 @@ public class UserService {
         return userSignUpService.signUp(dto);
     }
 
-    public UserResponseDto getUserExcept(Long currentUserId) {
-        return userMatchingService.getUserExcept(currentUserId);
+    public List<UserResponseDto> getUsersExcept(Long currentUserId) {
+        return userMatchingService.getUsersExcept(currentUserId);
     }
 
     public UserResponseDto getUser(Long userId) {

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -37,6 +37,27 @@ spring:
       hibernate.format_sql: true
       hibernate.default_batch_fetch_size: 1000
 
+  security:
+    oauth2:
+      client:
+        registration:
+          google:
+            client-id: ${GOOGLE_CLIENT_ID}
+            client-secret: ${GOOGLE_CLIENT_SECRET}
+            redirect-uri: "{baseUrl}/login/oauth2/code/{registrationId}"
+            scope:
+              - email
+              - profile
+        provider:
+          google:
+            user-name-attribute: sub
+      frontend:
+        redirect-uri: ${OAUTH2_FRONTEND_REDIRECT_URI}
+
+jwt:
+  secret: ${JWT_SECRET_BASE64}
+  expiration: 3600000 # 1 hour in ms
+
 #  # use data.sql file for dummy data
 #  sql.init.mode: always
 

--- a/src/test/java/flab/transtalk/user/service/user/UserMatchingServiceTest.java
+++ b/src/test/java/flab/transtalk/user/service/user/UserMatchingServiceTest.java
@@ -2,8 +2,6 @@ package flab.transtalk.user.service.user;
 
 
 import flab.transtalk.common.enums.LanguageSelection;
-import flab.transtalk.common.exception.NotFoundException;
-import flab.transtalk.common.exception.message.ExceptionMessages;
 import flab.transtalk.user.domain.Profile;
 import flab.transtalk.user.domain.User;
 import flab.transtalk.user.dto.res.UserResponseDto;
@@ -15,10 +13,14 @@ import org.mockito.InjectMocks;
 import org.mockito.BDDMockito;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Pageable;
 
 import java.time.LocalDate;
+import java.util.List;
+
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 
 @ExtendWith(MockitoExtension.class)
 @DisplayName("사용자 매칭 테스트")
@@ -45,26 +47,13 @@ public class UserMatchingServiceTest {
                         .selfIntroduction("")
                         .build())
                 .build();
-        BDDMockito.given(userRepository.findRandomUserExcept(currentUserId)).willReturn(user);
+        BDDMockito.given(userRepository.findAllExcept(eq(currentUserId), any(Pageable.class))).willReturn(List.of(user));
 
         // when
-        UserResponseDto result = userMatchingService.getUserExcept(currentUserId);
+        List<UserResponseDto> result = userMatchingService.getUsersExcept(currentUserId);
 
         // then
-        assertThat(result.getId()).isEqualTo(2L);
-        assertThat(result.getName()).isEqualTo("사용자2");
-    }
-
-    @Test
-    @DisplayName("매칭 사용자 없음 예외 발생 테스트")
-    void  testGetUserExcept_2(){
-        // given
-        Long currentUserId = 1L;
-        BDDMockito.given(userRepository.findRandomUserExcept(currentUserId)).willReturn(null);
-
-        // when & then
-        assertThatThrownBy(()->userMatchingService.getUserExcept(currentUserId))
-                .isInstanceOf(NotFoundException.class)
-                .hasMessageContaining(ExceptionMessages.NO_USER_FOUND);
+        assertThat(result.get(0).getId()).isEqualTo(2L);
+        assertThat(result.get(0).getName()).isEqualTo("사용자2");
     }
 }


### PR DESCRIPTION
## 목표
- Issue #6 해결
- Google OAuth2 + JWT 기반 소셜 로그인·회원가입 기능 제공

## 수행 내용
1. 빌드 및 설정
- spring-boot-starter-security, spring-boot-starter-oauth2-client, jjwt 의존성 추가
- application.yml에 OAuth Client·JWT secret·TTL 등 환경 변수화
2. AuthAccount entity 추가
- OAuth2 인증 정보 관리용 entity
3. User entity 필드 추가
- 사용자 UUID 기반 외부용 식별자, 이메일 필드 추가
4. 인증 및 인가 로직 추가
- OAuth2 프로필 수신 -> 신규 사용자 자동 저장
- 로그인 성공 시 JWT 발급 후 리다이렉트
- 요청 헤더의 JWT 검증 -> 인증 컨텍스트 주입
5. 보안 설정
- 인증 예외 범위 설정: /, /oauth2/**, /login/** → permitAll
- 인증 범위 설정: 그 외 모든 요청(/api/**) ->authenticated
- 세션 정책 STATELESS, 커스텀 JWT 필터 체인 등록

## 유의
- CSRF : 쿠키 기반 세션이 없고 Bearer JWT만 사용하므로 csrf().disable() 적용

## 시퀀스 다이어그램
- OAuth2 로그인 및 회원가입 & JWT 발급
<img width="1701" alt="스크린샷 2025-05-31 오후 10 53 44" src="https://github.com/user-attachments/assets/bf946f21-4a4a-4e0d-b2b6-709061674a49" />

-  보호 API 호출 시 JWT 인증
<img width="1266" alt="스크린샷 2025-05-31 오후 11 04 37" src="https://github.com/user-attachments/assets/c683be02-97a0-4614-9e51-8c8874e42168" />
