### PR TITLE
[#9, #16] CloudFront + Signed Cookie 전환 및 이미지 처리 로직 구체화

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -409,4 +409,7 @@ build/
 !**/src/main/**/build/
 !**/src/test/**/build/
 
+# key
+*.pem
+
 # End of https://www.toptal.com/developers/gitignore/api/macos,intellij,java,python,netbeans,visualstudiocode

--- a/build.gradle
+++ b/build.gradle
@@ -44,6 +44,8 @@ dependencies {
 	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
 	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 
+	implementation 'org.springframework.boot:spring-boot-configuration-processor'
+	annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'
     compileOnly 'org.projectlombok:lombok'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
 	runtimeOnly 'com.h2database:h2'

--- a/build.gradle
+++ b/build.gradle
@@ -38,6 +38,7 @@ dependencies {
 	implementation platform("software.amazon.awssdk:bom:${awsSdkVersion}")   	// SDK v2 BOM – 다중 모듈 버전 통일
 	implementation 'software.amazon.awssdk:s3'                                 	// S3 클라이언트 모듈만 사용
 	implementation 'org.apache.tika:tika-core:2.9.0'							// 실제 콘텐츠 타입을 판별을 위해 사용
+	implementation 'net.coobird:thumbnailator:0.4.19'
 
 	// JWT
 	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'

--- a/src/main/java/flab/transtalk/config/AwsConfig.java
+++ b/src/main/java/flab/transtalk/config/AwsConfig.java
@@ -6,7 +6,6 @@ import org.springframework.context.annotation.Configuration;
 import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.S3Client;
-import software.amazon.awssdk.services.s3.presigner.S3Presigner;
 
 @Configuration
 public class AwsConfig {
@@ -20,14 +19,6 @@ public class AwsConfig {
     public S3Client s3Client() {
         // DefaultCredentialsProvider: 환경 변수, EC2 Role 등 순차 탐색
         return S3Client.builder()
-                .region(Region.of(region))
-                .credentialsProvider(credentialsProvider)
-                .build();
-    }
-
-    @Bean
-    public S3Presigner s3Presigner(){
-        return S3Presigner.builder()
                 .region(Region.of(region))
                 .credentialsProvider(credentialsProvider)
                 .build();

--- a/src/main/java/flab/transtalk/config/CloudFrontConfig.java
+++ b/src/main/java/flab/transtalk/config/CloudFrontConfig.java
@@ -1,0 +1,46 @@
+package flab.transtalk.config;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.security.KeyFactory;
+import java.security.NoSuchAlgorithmException;
+import java.security.interfaces.RSAPrivateKey;
+import java.security.spec.InvalidKeySpecException;
+import java.security.spec.PKCS8EncodedKeySpec;
+import java.util.Base64;
+import java.util.List;
+
+@Getter
+@Setter
+@Configuration
+@ConfigurationProperties(prefix = "app.aws.cloudfront")
+public class CloudFrontConfig {
+    private String domain;
+    private String keyPairId;
+    private String privateKeyPath;
+    private List<String> resourcePaths;
+
+    @Bean
+    public RSAPrivateKey cloudFrontPrivateKey() throws IOException, NoSuchAlgorithmException, InvalidKeySpecException {
+        File pemFile = new File(privateKeyPath);
+        if (!pemFile.exists()) {
+            throw new FileNotFoundException("Private key file not found");
+        }
+        String key = Files.readString(pemFile.toPath())
+                .replace("-----BEGIN PRIVATE KEY-----", "")
+                .replace("-----END PRIVATE KEY-----", "")
+                .replaceAll("\\s", "");
+        byte[] decoded = Base64.getDecoder().decode(key);
+        PKCS8EncodedKeySpec keySpec = new PKCS8EncodedKeySpec(decoded);
+        return (RSAPrivateKey) KeyFactory.getInstance("RSA").generatePrivate(keySpec);
+    }
+}

--- a/src/main/java/flab/transtalk/config/ServiceConfigConstants.java
+++ b/src/main/java/flab/transtalk/config/ServiceConfigConstants.java
@@ -7,4 +7,10 @@ import lombok.NoArgsConstructor;
 public class ServiceConfigConstants {
     public static final long SIGNED_COOKIE_DURATION_HOUR = 6;
     public static final int MATCHING_USERS_MAX_NUMBER = 4;
+    public static final int PROFILE_SMALL_IMAGE_WIDTH = 640;
+    public static final int PROFILE_SMALL_IMAGE_HEIGHT = 640;
+    public static final int POST_LARGE_IMAGE_WIDTH = 1080;
+    public static final int POST_LARGE_IMAGE_HEIGHT = 1080;
+    public static final int POST_SMALL_IMAGE_WIDTH = 640;
+    public static final int POST_SMALL_IMAGE_HEIGHT = 640;
 }

--- a/src/main/java/flab/transtalk/config/ServiceConfigConstants.java
+++ b/src/main/java/flab/transtalk/config/ServiceConfigConstants.java
@@ -5,7 +5,6 @@ import lombok.NoArgsConstructor;
 
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class ServiceConfigConstants {
-    public static final String S3_POST_IMAGE_FOLDER_NAME = "posts/";
-    public static final long PRESIGNED_URL_DURATION_HOUR = 6;
+    public static final long SIGNED_COOKIE_DURATION_HOUR = 6;
     public static final int MATCHING_USERS_MAX_NUMBER = 4;
 }

--- a/src/main/java/flab/transtalk/user/controller/PostController.java
+++ b/src/main/java/flab/transtalk/user/controller/PostController.java
@@ -1,8 +1,11 @@
 package flab.transtalk.user.controller;
 
+import com.nimbusds.jose.JOSEException;
 import flab.transtalk.user.dto.req.PostCreateRequestDto;
 import flab.transtalk.user.dto.res.PostResponseDto;
+import flab.transtalk.user.service.image.CloudFrontService;
 import flab.transtalk.user.service.post.PostService;
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -17,20 +20,22 @@ import static org.springframework.http.MediaType.MULTIPART_FORM_DATA_VALUE;
 public class PostController {
 
     private final PostService postService;
+    private final CloudFrontService cloudFrontService;
 
     @PostMapping(consumes = MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<PostResponseDto> createPost(
+                HttpServletResponse response,
                 @RequestParam("briefContext") String briefContext,
                 @RequestParam("imageFile") MultipartFile imageFile,
-                @RequestParam("profileId") Long profileId) {
+                @RequestParam("profileId") Long profileId) throws JOSEException {
 
         PostCreateRequestDto dto = PostCreateRequestDto.builder()
                 .briefContext(briefContext)
                 .imageFile(imageFile)
                 .profileId(profileId)
                 .build();
-
-        return ResponseEntity.status(HttpStatus.CREATED).body(postService.createPost(dto));
+        cloudFrontService.issueSignedCookie(response);
+        return ResponseEntity.status(HttpStatus.CREATED).body(postService. createPost(dto));
     }
 
     @GetMapping("/{postId}")

--- a/src/main/java/flab/transtalk/user/controller/PostController.java
+++ b/src/main/java/flab/transtalk/user/controller/PostController.java
@@ -39,12 +39,17 @@ public class PostController {
     }
 
     @GetMapping("/{postId}")
-    public ResponseEntity<PostResponseDto> get(@PathVariable Long postId){
+    public ResponseEntity<PostResponseDto> get(
+            HttpServletResponse response,
+            @PathVariable Long postId
+    ) throws JOSEException {
+        cloudFrontService.issueSignedCookie(response);
         return ResponseEntity.status(HttpStatus.OK).body(postService.getPost(postId));
     }
 
     @DeleteMapping("/{postId}")
-    public ResponseEntity<Void> deletePost(@PathVariable Long postId){
+    public ResponseEntity<Void> deletePost(
+            @PathVariable Long postId){
         postService.deletePost(postId);
         return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
     }

--- a/src/main/java/flab/transtalk/user/controller/ProfileController.java
+++ b/src/main/java/flab/transtalk/user/controller/ProfileController.java
@@ -1,12 +1,16 @@
 package flab.transtalk.user.controller;
 
+import com.nimbusds.jose.JOSEException;
 import flab.transtalk.user.dto.req.ProfileUpdateRequestDto;
 import flab.transtalk.user.dto.res.ProfileResponseDto;
+import flab.transtalk.user.service.image.CloudFrontService;
 import flab.transtalk.user.service.profile.ProfileService;
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
 @RestController
 @RequestMapping("/api/profile")
@@ -14,17 +18,31 @@ import org.springframework.web.bind.annotation.*;
 public class ProfileController {
 
     private final ProfileService profileService;
+    private final CloudFrontService cloudFrontService;
+
+    @PutMapping("/{profileId}/image")
+    public ResponseEntity<ProfileResponseDto> updateProfile(
+            HttpServletResponse response,
+            @PathVariable Long profileId,
+            @RequestParam("imageFile") MultipartFile imageFile) throws JOSEException {
+        cloudFrontService.issueSignedCookie(response);
+        return ResponseEntity.status(HttpStatus.OK).body(profileService.updateProfileImage(profileId, imageFile));
+    }
 
     @PutMapping("/{profileId}")
     public ResponseEntity<ProfileResponseDto> updateProfile(
+            HttpServletResponse response,
             @PathVariable Long profileId,
-            @RequestBody ProfileUpdateRequestDto dto){
+            @RequestBody ProfileUpdateRequestDto dto) throws JOSEException {
+        cloudFrontService.issueSignedCookie(response);
         return ResponseEntity.status(HttpStatus.OK).body(profileService.updateProfile(profileId, dto));
     }
 
     @GetMapping("/{profileId}")
-    public ResponseEntity<ProfileResponseDto> getProfile(@PathVariable Long profileId){
+    public ResponseEntity<ProfileResponseDto> getProfile(
+            HttpServletResponse response,
+            @PathVariable Long profileId) throws JOSEException {
+        cloudFrontService.issueSignedCookie(response);
         return ResponseEntity.status(HttpStatus.OK).body(profileService.getProfile(profileId));
     }
-
 }

--- a/src/main/java/flab/transtalk/user/domain/Profile.java
+++ b/src/main/java/flab/transtalk/user/domain/Profile.java
@@ -58,6 +58,9 @@ public class Profile {
     public void setLanguage(LanguageSelection language){
         this.language = language;
     }
+    public void setImageKey(String imageKey) {
+        this.imageKey = imageKey;
+    }
 
     public void setUser(User user) {
         if (this.user != null && this.user != user){

--- a/src/main/java/flab/transtalk/user/domain/Profile.java
+++ b/src/main/java/flab/transtalk/user/domain/Profile.java
@@ -35,6 +35,9 @@ public class Profile {
     @Enumerated(EnumType.STRING)
     private LanguageSelection language;
 
+    @Column(nullable = true, length = 512)
+    private String imageKey;
+
     @OneToOne(fetch = FetchType.EAGER)
     @JoinColumn(name = "user_id")
     private User user;

--- a/src/main/java/flab/transtalk/user/dto/req/PostCreateRequestDto.java
+++ b/src/main/java/flab/transtalk/user/dto/req/PostCreateRequestDto.java
@@ -6,7 +6,7 @@ import org.springframework.web.multipart.MultipartFile;
 @Value
 @Builder
 public class PostCreateRequestDto {
-    private String briefContext;
-    private MultipartFile imageFile;
-    private Long profileId;
+    String briefContext;
+    MultipartFile imageFile;
+    Long profileId;
 }

--- a/src/main/java/flab/transtalk/user/dto/req/ProfileCreateRequestDto.java
+++ b/src/main/java/flab/transtalk/user/dto/req/ProfileCreateRequestDto.java
@@ -23,6 +23,8 @@ public class ProfileCreateRequestDto {
 
     public Profile toEntity(){
         return Profile.builder()
+                .name(this.name)
+                .birthDate(this.birthDate)
                 .selfIntroduction(this.selfIntroduction)
                 .language(this.language)
                 .build();

--- a/src/main/java/flab/transtalk/user/dto/res/PostResponseDto.java
+++ b/src/main/java/flab/transtalk/user/dto/res/PostResponseDto.java
@@ -5,11 +5,13 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Value;
 
+import java.time.LocalDate;
+
 @Value
 @Builder
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class PostResponseDto {
-    private Long id;
-    private String briefContext;
-    private String imagePresignedUrl;
+    Long id;
+    String briefContext;
+    String imagePresignedUrl;
 }

--- a/src/main/java/flab/transtalk/user/dto/res/PostResponseDto.java
+++ b/src/main/java/flab/transtalk/user/dto/res/PostResponseDto.java
@@ -5,13 +5,11 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Value;
 
-import java.time.LocalDate;
-
 @Value
 @Builder
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class PostResponseDto {
     Long id;
     String briefContext;
-    String imagePresignedUrl;
+    String imageUrl;
 }

--- a/src/main/java/flab/transtalk/user/dto/res/PostResponseDto.java
+++ b/src/main/java/flab/transtalk/user/dto/res/PostResponseDto.java
@@ -12,5 +12,6 @@ public class PostResponseDto {
     Long id;
     String briefContext;
     String imageKey;
-    String imageUrl;
+    String largeImageUrl;
+    String smallImageUrl;
 }

--- a/src/main/java/flab/transtalk/user/dto/res/PostResponseDto.java
+++ b/src/main/java/flab/transtalk/user/dto/res/PostResponseDto.java
@@ -11,5 +11,6 @@ import lombok.Value;
 public class PostResponseDto {
     Long id;
     String briefContext;
+    String imageKey;
     String imageUrl;
 }

--- a/src/main/java/flab/transtalk/user/dto/res/ProfileResponseDto.java
+++ b/src/main/java/flab/transtalk/user/dto/res/ProfileResponseDto.java
@@ -27,14 +27,4 @@ public class ProfileResponseDto {
     String imageUrl;
     @Builder.Default
     List<PostResponseDto> posts = new ArrayList<>();
-
-    public static ProfileResponseDto from(Profile entity){
-        return ProfileResponseDto.builder()
-                .id(entity.getId())
-                .name(entity.getName())
-                .birthDate(entity.getBirthDate())
-                .selfIntroduction(entity.getSelfIntroduction())
-                .language(entity.getLanguage())
-                .build();
-    }
 }

--- a/src/main/java/flab/transtalk/user/dto/res/ProfileResponseDto.java
+++ b/src/main/java/flab/transtalk/user/dto/res/ProfileResponseDto.java
@@ -24,7 +24,8 @@ public class ProfileResponseDto {
     String selfIntroduction;
     LanguageSelection language;
     String imageKey;
-    String imageUrl;
+    String largeImageUrl;
+    String smallImageUrl;
     @Builder.Default
     List<PostResponseDto> posts = new ArrayList<>();
 }

--- a/src/main/java/flab/transtalk/user/dto/res/ProfileResponseDto.java
+++ b/src/main/java/flab/transtalk/user/dto/res/ProfileResponseDto.java
@@ -23,6 +23,8 @@ public class ProfileResponseDto {
     LocalDate birthDate;
     String selfIntroduction;
     LanguageSelection language;
+    String imageKey;
+    String imageUrl;
     @Builder.Default
     List<PostResponseDto> posts = new ArrayList<>();
 

--- a/src/main/java/flab/transtalk/user/service/image/CloudFrontService.java
+++ b/src/main/java/flab/transtalk/user/service/image/CloudFrontService.java
@@ -57,6 +57,7 @@ public class CloudFrontService {
                 "CloudFront-Key-Pair-Id", cloudFrontConfig.getKeyPairId()
         );
     }
+
     public void attachSignedCookies(HttpServletResponse response, Map<String, String> cookies, long ttlSeconds) {
         cookies.forEach((key, value) -> {
             ResponseCookie cookie = ResponseCookie.from(key, value)
@@ -69,12 +70,17 @@ public class CloudFrontService {
             response.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());
         });
     }
+
     public void issueSignedCookie(HttpServletResponse response) throws JOSEException {
         Duration ttl = Duration.ofHours(ServiceConfigConstants.SIGNED_COOKIE_DURATION_HOUR);
         Map<String, String> cookies = generateSignedCookies(ttl);
         attachSignedCookies(response, cookies, ttl.toSeconds());
     }
+
     public String getImageUrl(String imageKey){
+        if (imageKey==null){
+            return null;
+        }
         return String.format("https://%s/%s",cloudFrontConfig.getDomain(), imageKey);
     }
 }

--- a/src/main/java/flab/transtalk/user/service/image/CloudFrontService.java
+++ b/src/main/java/flab/transtalk/user/service/image/CloudFrontService.java
@@ -1,0 +1,80 @@
+package flab.transtalk.user.service.image;
+
+import com.nimbusds.jose.*;
+import com.nimbusds.jose.crypto.RSASSASigner;
+import flab.transtalk.config.CloudFrontConfig;
+import flab.transtalk.config.ServiceConfigConstants;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseCookie;
+import org.springframework.stereotype.Service;
+
+import java.security.interfaces.RSAPrivateKey;
+import java.time.Duration;
+import java.util.Base64;
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+public class CloudFrontService {
+    private final RSAPrivateKey privateKey;
+    private final CloudFrontConfig cloudFrontConfig;
+
+    public Map<String, String> generateSignedCookies(Duration duration) throws JOSEException {
+        long expires = System.currentTimeMillis() + duration.toMillis();
+
+        StringBuilder statementBuilder = new StringBuilder();
+        for (String path : cloudFrontConfig.getResourcePaths()) {
+            statementBuilder.append(String.format("""
+                {
+                  "Resource": "https://%s/%s",
+                  "Condition": {
+                    "DateLessThan": {"AWS:EpochTime": %d}
+                  }
+                },
+                """, cloudFrontConfig.getDomain(), path, expires / 1000));
+        }
+        String policy = String.format("""
+            {
+              "Statement": [
+                %s
+              ]
+            }
+            """, statementBuilder.toString().replaceAll(",$", ""));
+
+        JWSSigner signer = new RSASSASigner(privateKey);
+        JWSObject jws = new JWSObject(
+                new JWSHeader.Builder(JWSAlgorithm.RS256).build(),
+                new Payload(policy)
+        );
+        jws.sign(signer);
+        String signature = Base64.getUrlEncoder().withoutPadding().encodeToString(jws.serialize().getBytes());
+
+        return Map.of(
+                "CloudFront-Policy", Base64.getUrlEncoder().withoutPadding().encodeToString(policy.getBytes()),
+                "CloudFront-Signature", signature,
+                "CloudFront-Key-Pair-Id", cloudFrontConfig.getKeyPairId()
+        );
+    }
+    public void attachSignedCookies(HttpServletResponse response, Map<String, String> cookies, long ttlSeconds) {
+        cookies.forEach((key, value) -> {
+            ResponseCookie cookie = ResponseCookie.from(key, value)
+                    .path("/")
+                    .httpOnly(true)
+                    .secure(true)
+                    .maxAge(ttlSeconds)
+                    .sameSite("Lax")
+                    .build();
+            response.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());
+        });
+    }
+    public void issueSignedCookie(HttpServletResponse response) throws JOSEException {
+        Duration ttl = Duration.ofHours(ServiceConfigConstants.SIGNED_COOKIE_DURATION_HOUR);
+        Map<String, String> cookies = generateSignedCookies(ttl);
+        attachSignedCookies(response, cookies, ttl.toSeconds());
+    }
+    public String getImageUrl(String imageKey){
+        return String.format("https://%s/%s",cloudFrontConfig.getDomain(), imageKey);
+    }
+}

--- a/src/main/java/flab/transtalk/user/service/image/ImageService.java
+++ b/src/main/java/flab/transtalk/user/service/image/ImageService.java
@@ -42,7 +42,6 @@ public class ImageService {
     // image key 생성 및 이미지 업로드
     public String uploadImageFile(MultipartFile file) throws IOException {
         String detectedContentType = tika.detect(file.getInputStream());
-        // image key 구성: post image folder 이름 + UUID + LocalDate + 확장자
         String extension = SUPPORTED_IMAGE_TYPES.get(detectedContentType);
         if (extension == null){
             throw new BadRequestException(
@@ -50,6 +49,7 @@ public class ImageService {
             );
         }
         String timestamp = LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyyMMdd'T'HHmmss"));
+        // image key 구성: post image folder 이름 + UUID + LocalDate + 확장자
         String generatedImageKey = ServiceConfigConstants.S3_POST_IMAGE_FOLDER_NAME + UUID.randomUUID() + "-" + timestamp + extension;
 
         PutObjectRequest req = PutObjectRequest.builder()

--- a/src/main/java/flab/transtalk/user/service/image/S3Service.java
+++ b/src/main/java/flab/transtalk/user/service/image/S3Service.java
@@ -1,4 +1,4 @@
-package flab.transtalk.user.service.post;
+package flab.transtalk.user.service.image;
 
 import flab.transtalk.common.exception.BadRequestException;
 import flab.transtalk.common.exception.NotFoundException;
@@ -24,7 +24,7 @@ import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor
-public class ImageService {
+public class S3Service {
     // AwsConfig에서 등록한 Bean 사용
     private final S3Client s3Client;
     private final S3Presigner presigner;

--- a/src/main/java/flab/transtalk/user/service/image/S3Service.java
+++ b/src/main/java/flab/transtalk/user/service/image/S3Service.java
@@ -3,7 +3,9 @@ package flab.transtalk.user.service.image;
 import flab.transtalk.common.exception.BadRequestException;
 import flab.transtalk.common.exception.NotFoundException;
 import flab.transtalk.common.exception.message.ExceptionMessages;
+import flab.transtalk.config.ServiceConfigConstants;
 import lombok.RequiredArgsConstructor;
+import net.coobird.thumbnailator.Thumbnails;
 import org.apache.tika.Tika;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
@@ -12,6 +14,9 @@ import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.*;
 
+import javax.imageio.ImageIO;
+import java.awt.image.BufferedImage;
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
@@ -29,11 +34,60 @@ public class S3Service {
     private String profileResourcePath;
     @Value("${app.aws.s3.post-resource-path}")
     private String postResourcePath;
+    @Value("${app.aws.s3.suffix.large}")
+    private String LARGE_SUFFIX;
+    @Value("${app.aws.s3.suffix.small}")
+    private String SMALL_SUFFIX;
+
 
     public static final Map<String, String> SUPPORTED_IMAGE_TYPES = Map.of(
             "image/jpeg", ".jpg",
             "image/png", ".png"
     );
+
+    public void uploadImageFile(MultipartFile file, String imageKey, String contentType) throws IOException {
+        PutObjectRequest req = PutObjectRequest.builder()
+                .bucket(bucket)
+                .key(imageKey)
+                .contentType(contentType)
+                .acl(ObjectCannedACL.PRIVATE)
+                .build();
+
+        s3Client.putObject(req, RequestBody.fromInputStream(file.getInputStream(), file.getSize()));
+    }
+
+    public void uploadImageFileBytes(byte[] fileBytes, String imageKey, String contentType) {
+        PutObjectRequest req = PutObjectRequest.builder()
+                .bucket(bucket)
+                .key(imageKey)
+                .contentType(contentType)
+                .acl(ObjectCannedACL.PRIVATE)
+                .build();
+
+        s3Client.putObject(req, RequestBody.fromBytes(fileBytes));
+    }
+
+    public BufferedImage cropToSquare(MultipartFile file) throws IOException {
+        BufferedImage originalImage = ImageIO.read(file.getInputStream());
+        int width = originalImage.getWidth();
+        int height = originalImage.getHeight();
+
+        int squareSize = Math.min(width, height);
+        int x = (width - squareSize) / 2;
+        int y = (height - squareSize) / 2;
+
+        BufferedImage croppedImage = originalImage.getSubimage(x, y, squareSize, squareSize);
+        return croppedImage;
+    }
+
+    public byte[] resizeImage(BufferedImage croppedImage, String extension, int width, int height) throws IOException {
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        Thumbnails.of(croppedImage)
+                .size(width, height)
+                .outputFormat(extension)
+                .toOutputStream(outputStream);
+        return outputStream.toByteArray();
+    }
 
     public String uploadProfileImageFile(MultipartFile file, Long userId) throws IOException {
         String detectedContentType = tika.detect(file.getInputStream());
@@ -43,17 +97,15 @@ public class S3Service {
                     String.format(ExceptionMessages.UNSUPPORTED_IMAGE_FORMAT, detectedContentType)
             );
         }
-        String timestamp = LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyyMMdd'T'HHmmss"));
-        String generatedImageKey = generateImageKey(profileResourcePath, userId, timestamp, extension);
+        String generatedImageKey = generateImageKey(file, profileResourcePath, userId, extension);
 
-        PutObjectRequest req = PutObjectRequest.builder()
-                .bucket(bucket)
-                .key(generatedImageKey)
-                .contentType(detectedContentType)
-                .acl(ObjectCannedACL.PRIVATE)
-                .build();
+        String largeImageKey = getImageKeyWithSuffix(generatedImageKey, LARGE_SUFFIX);
+        uploadImageFile(file, largeImageKey, detectedContentType);
 
-        s3Client.putObject(req, RequestBody.fromInputStream(file.getInputStream(), file.getSize()));
+        String smallImageKey = getImageKeyWithSuffix(generatedImageKey, SMALL_SUFFIX);
+        byte[] smallImageBytes = resizeImage(cropToSquare(file), extension.substring(1), ServiceConfigConstants.PROFILE_SMALL_IMAGE_WIDTH, ServiceConfigConstants.PROFILE_SMALL_IMAGE_HEIGHT);
+        uploadImageFileBytes(smallImageBytes, smallImageKey, detectedContentType);
+
         return generatedImageKey;
     }
 
@@ -65,21 +117,26 @@ public class S3Service {
                     String.format(ExceptionMessages.UNSUPPORTED_IMAGE_FORMAT, detectedContentType)
             );
         }
-        String timestamp = LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyyMMdd'T'HHmmss"));
-        String generatedImageKey = generateImageKey(postResourcePath, profileId, timestamp, extension);
+        String generatedImageKey = generateImageKey(file, postResourcePath, profileId, extension);
+        BufferedImage croppedImage = cropToSquare(file);
 
-        PutObjectRequest req = PutObjectRequest.builder()
-                .bucket(bucket)
-                .key(generatedImageKey)
-                .contentType(detectedContentType)
-                .acl(ObjectCannedACL.PRIVATE)
-                .build();
+        String largeImageKey = getImageKeyWithSuffix(generatedImageKey, LARGE_SUFFIX);
+        byte[] largeImageBytes = resizeImage(croppedImage, extension.substring(1), ServiceConfigConstants.POST_LARGE_IMAGE_WIDTH, ServiceConfigConstants.POST_LARGE_IMAGE_HEIGHT);
+        uploadImageFileBytes(largeImageBytes, largeImageKey, detectedContentType);
 
-        s3Client.putObject(req, RequestBody.fromInputStream(file.getInputStream(), file.getSize()));
+        String smallImageKey = getImageKeyWithSuffix(generatedImageKey, SMALL_SUFFIX);
+        byte[] smallImageBytes = resizeImage(croppedImage, extension.substring(1), ServiceConfigConstants.POST_SMALL_IMAGE_WIDTH, ServiceConfigConstants.POST_SMALL_IMAGE_HEIGHT);
+        uploadImageFileBytes(smallImageBytes, smallImageKey, detectedContentType);
+
         return generatedImageKey;
     }
 
     public void deleteImageFile(String imageKey) {
+        deleteImageFileByDetailImageKey(getImageKeyWithSuffix(imageKey, LARGE_SUFFIX));
+        deleteImageFileByDetailImageKey(getImageKeyWithSuffix(imageKey, SMALL_SUFFIX));
+    }
+
+    public void deleteImageFileByDetailImageKey(String imageKey) {
         try {
             s3Client.deleteObject(DeleteObjectRequest.builder()
                     .bucket(bucket)
@@ -97,7 +154,20 @@ public class S3Service {
         }
     }
 
-    public String generateImageKey(String resourcePath, Long id, String timestamp, String extension){
-        return resourcePath + "/" + id.toString() + "/" + UUID.randomUUID() + "-" + timestamp + extension;
+    public String generateImageKey(MultipartFile file, String resourcePath, Long id, String extension) throws IOException {
+        return resourcePath + "/" + id.toString() + "/" + UUID.randomUUID() + extension;
+    }
+    public String getImageKeyWithSuffix(String imageKey, String suffix){
+        if (imageKey == null || imageKey.isEmpty()) {
+            throw new IllegalArgumentException("imageKey must not be null or empty");
+        }
+
+        int lastDotIndex = imageKey.lastIndexOf(".");
+        if (lastDotIndex == -1 || lastDotIndex == imageKey.length() - 1 || !SUPPORTED_IMAGE_TYPES.values().contains(imageKey.substring(lastDotIndex+1))) {
+            throw new IllegalArgumentException("Invalid imageKey format: missing or malformed file extension.");
+        }
+        String base = imageKey.substring(0, lastDotIndex);
+        String ext = imageKey.substring(lastDotIndex);
+        return base + suffix + ext;
     }
 }

--- a/src/main/java/flab/transtalk/user/service/post/PostDtoMapper.java
+++ b/src/main/java/flab/transtalk/user/service/post/PostDtoMapper.java
@@ -1,0 +1,22 @@
+package flab.transtalk.user.service.post;
+
+import flab.transtalk.user.domain.Post;
+import flab.transtalk.user.dto.res.PostResponseDto;
+import flab.transtalk.user.service.image.CloudFrontService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class PostDtoMapper {
+    private final CloudFrontService cloudFrontService;
+
+    public PostResponseDto toDto(Post post){
+        return PostResponseDto.builder()
+                .id(post.getId())
+                .briefContext(post.getBriefContext())
+                .imageKey(post.getImageKey())
+                .imageUrl(cloudFrontService.getImageUrl(post.getImageKey()))
+                .build();
+    }
+}

--- a/src/main/java/flab/transtalk/user/service/post/PostDtoMapper.java
+++ b/src/main/java/flab/transtalk/user/service/post/PostDtoMapper.java
@@ -16,7 +16,8 @@ public class PostDtoMapper {
                 .id(post.getId())
                 .briefContext(post.getBriefContext())
                 .imageKey(post.getImageKey())
-                .imageUrl(cloudFrontService.getImageUrl(post.getImageKey()))
+                .largeImageUrl(cloudFrontService.getLargeImageUrl(post.getImageKey()))
+                .smallImageUrl(cloudFrontService.getSmallImageUrl(post.getImageKey()))
                 .build();
     }
 }

--- a/src/main/java/flab/transtalk/user/service/post/PostService.java
+++ b/src/main/java/flab/transtalk/user/service/post/PostService.java
@@ -3,18 +3,18 @@ package flab.transtalk.user.service.post;
 import flab.transtalk.common.exception.BadRequestException;
 import flab.transtalk.common.exception.NotFoundException;
 import flab.transtalk.common.exception.message.ExceptionMessages;
-import flab.transtalk.config.ServiceConfigConstants;
 import flab.transtalk.user.domain.Post;
 import flab.transtalk.user.domain.Profile;
 import flab.transtalk.user.dto.req.PostCreateRequestDto;
 import flab.transtalk.user.dto.res.PostResponseDto;
 import flab.transtalk.user.repository.PostRepository;
 import flab.transtalk.user.repository.ProfileRepository;
+import flab.transtalk.user.service.image.CloudFrontService;
+import flab.transtalk.user.service.image.S3Service;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import java.io.IOException;
-import java.time.Duration;
 import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -25,7 +25,8 @@ public class PostService {
 
     private final PostRepository postRepository;
     private final ProfileRepository profileRepository;
-    private final ImageService imageService;
+    private final S3Service imageService;
+    private final CloudFrontService cloudFrontService;
 
     // Post 생성 (+ 이미지 업로드)
     public PostResponseDto createPost(PostCreateRequestDto dto) {
@@ -36,7 +37,7 @@ public class PostService {
                 ));
         String generatedImageKey;
         try {
-            generatedImageKey = imageService.uploadImageFile(dto.getImageFile());
+            generatedImageKey = imageService.uploadPostImageFile(dto.getImageFile(), profile.getId());
         } catch (IOException e) {
             throw new BadRequestException(ExceptionMessages.IMAGE_UPLOAD_FAILED);
         }
@@ -47,14 +48,11 @@ public class PostService {
         post.setProfile(profile);
 
         Post saved = postRepository.save(post);
-        String presignedUrl = imageService.generatePresignedUrl(
-                generatedImageKey,
-                Duration.ofHours(ServiceConfigConstants.PRESIGNED_URL_DURATION_HOUR)
-        );
+        String imageUrl = cloudFrontService.getImageUrl(generatedImageKey);
         return PostResponseDto.builder()
                 .id(saved.getId())
                 .briefContext(saved.getBriefContext())
-                .imagePresignedUrl(presignedUrl)      // presignedURL 반환
+                .imageUrl(imageUrl)
                 .build();
     }
 
@@ -65,14 +63,10 @@ public class PostService {
                         ExceptionMessages.POST_NOT_FOUND,
                         postId.toString()
                 ));
-        String presignedUrl = imageService.generatePresignedUrl(
-                post.getImageKey(),
-                Duration.ofHours(ServiceConfigConstants.PRESIGNED_URL_DURATION_HOUR)
-        );
         return PostResponseDto.builder()
                 .id(post.getId())
                 .briefContext(post.getBriefContext())
-                .imagePresignedUrl(presignedUrl)
+                .imageUrl(cloudFrontService.getImageUrl(post.getImageKey()))
                 .build();
     }
 
@@ -96,12 +90,7 @@ public class PostService {
                 .map(post -> PostResponseDto.builder()
                         .id(post.getId())
                         .briefContext(post.getBriefContext())
-                        .imagePresignedUrl(
-                                imageService.generatePresignedUrl(
-                                        post.getImageKey(),
-                                        Duration.ofHours(ServiceConfigConstants.PRESIGNED_URL_DURATION_HOUR)
-                                )
-                        )
+                        .imageUrl(cloudFrontService.getImageUrl(post.getImageKey()))
                         .build())
                 .collect(Collectors.toList());
     }

--- a/src/main/java/flab/transtalk/user/service/post/PostService.java
+++ b/src/main/java/flab/transtalk/user/service/post/PostService.java
@@ -22,7 +22,7 @@ public class PostService {
     private final PostRepository postRepository;
     private final PostDtoMapper postDtoMapper;
     private final ProfileRepository profileRepository;
-    private final S3Service imageService;
+    private final S3Service s3Service;
 
     public PostResponseDto createPost(PostCreateRequestDto dto) {
         Profile profile = profileRepository.findById(dto.getProfileId())
@@ -32,7 +32,7 @@ public class PostService {
                 ));
         String generatedImageKey;
         try {
-            generatedImageKey = imageService.uploadPostImageFile(dto.getImageFile(), profile.getId());
+            generatedImageKey = s3Service.uploadPostImageFile(dto.getImageFile(), profile.getId());
         } catch (IOException e) {
             throw new BadRequestException(ExceptionMessages.IMAGE_UPLOAD_FAILED);
         }
@@ -62,7 +62,7 @@ public class PostService {
                         postId.toString()
                 )
         );
-        imageService.deleteImageFile(post.getImageKey());
+        s3Service.deleteImageFile(post.getImageKey());
         postRepository.delete(post);
     }
 }

--- a/src/main/java/flab/transtalk/user/service/post/PostService.java
+++ b/src/main/java/flab/transtalk/user/service/post/PostService.java
@@ -9,26 +9,21 @@ import flab.transtalk.user.dto.req.PostCreateRequestDto;
 import flab.transtalk.user.dto.res.PostResponseDto;
 import flab.transtalk.user.repository.PostRepository;
 import flab.transtalk.user.repository.ProfileRepository;
-import flab.transtalk.user.service.image.CloudFrontService;
 import flab.transtalk.user.service.image.S3Service;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import java.io.IOException;
-import java.util.Collections;
-import java.util.List;
-import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
 public class PostService {
 
     private final PostRepository postRepository;
+    private final PostDtoMapper postDtoMapper;
     private final ProfileRepository profileRepository;
     private final S3Service imageService;
-    private final CloudFrontService cloudFrontService;
 
-    // Post 생성 (+ 이미지 업로드)
     public PostResponseDto createPost(PostCreateRequestDto dto) {
         Profile profile = profileRepository.findById(dto.getProfileId())
                 .orElseThrow(() -> new NotFoundException(
@@ -48,29 +43,18 @@ public class PostService {
         post.setProfile(profile);
 
         Post saved = postRepository.save(post);
-        String imageUrl = cloudFrontService.getImageUrl(generatedImageKey);
-        return PostResponseDto.builder()
-                .id(saved.getId())
-                .briefContext(saved.getBriefContext())
-                .imageUrl(imageUrl)
-                .build();
+        return postDtoMapper.toDto(saved);
     }
 
-    // Post 조회
     public PostResponseDto getPost(Long postId){
         Post post = postRepository.findById(postId)
                 .orElseThrow(() -> new NotFoundException(
                         ExceptionMessages.POST_NOT_FOUND,
                         postId.toString()
                 ));
-        return PostResponseDto.builder()
-                .id(post.getId())
-                .briefContext(post.getBriefContext())
-                .imageUrl(cloudFrontService.getImageUrl(post.getImageKey()))
-                .build();
+        return postDtoMapper.toDto(post);
     }
 
-    // Post 삭제
     public void deletePost(Long postId) {
         Post post = postRepository.findById(postId).orElseThrow(() ->
                 new NotFoundException(
@@ -80,18 +64,5 @@ public class PostService {
         );
         imageService.deleteImageFile(post.getImageKey());
         postRepository.delete(post);
-    }
-
-    public List<PostResponseDto> getPosts(List<Post> posts) {
-        if (posts == null){
-            return Collections.emptyList();
-        }
-        return posts.stream()
-                .map(post -> PostResponseDto.builder()
-                        .id(post.getId())
-                        .briefContext(post.getBriefContext())
-                        .imageUrl(cloudFrontService.getImageUrl(post.getImageKey()))
-                        .build())
-                .collect(Collectors.toList());
     }
 }

--- a/src/main/java/flab/transtalk/user/service/profile/ProfileDtoMapper.java
+++ b/src/main/java/flab/transtalk/user/service/profile/ProfileDtoMapper.java
@@ -24,7 +24,8 @@ public class ProfileDtoMapper {
                 .selfIntroduction(profile.getSelfIntroduction())
                 .language(profile.getLanguage())
                 .imageKey(profile.getImageKey())
-                .imageUrl(cloudFrontService.getImageUrl(profile.getImageKey()))
+                .largeImageUrl(cloudFrontService.getLargeImageUrl(profile.getImageKey()))
+                .smallImageUrl(cloudFrontService.getSmallImageUrl(profile.getImageKey()))
                 .posts(profile.getPosts()!=null?
                         profile.getPosts().stream().map((Post post)->
                                 postDtoMapper.toDto(post)

--- a/src/main/java/flab/transtalk/user/service/profile/ProfileDtoMapper.java
+++ b/src/main/java/flab/transtalk/user/service/profile/ProfileDtoMapper.java
@@ -1,0 +1,35 @@
+package flab.transtalk.user.service.profile;
+
+import flab.transtalk.user.domain.Post;
+import flab.transtalk.user.domain.Profile;
+import flab.transtalk.user.dto.res.ProfileResponseDto;
+import flab.transtalk.user.service.image.CloudFrontService;
+import flab.transtalk.user.service.post.PostDtoMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class ProfileDtoMapper {
+    private CloudFrontService cloudFrontService;
+    private PostDtoMapper postDtoMapper;
+
+    public ProfileResponseDto toDto(Profile profile){
+        return ProfileResponseDto.builder()
+                .id(profile.getId())
+                .name(profile.getName())
+                .birthDate(profile.getBirthDate())
+                .selfIntroduction(profile.getSelfIntroduction())
+                .language(profile.getLanguage())
+                .imageKey(profile.getImageKey())
+                .imageUrl(cloudFrontService.getImageUrl(profile.getImageKey()))
+                .posts(profile.getPosts()!=null?
+                        profile.getPosts().stream().map((Post post)->
+                                postDtoMapper.toDto(post)
+                        ).toList() :
+                        List.of()
+                ).build();
+    }
+}

--- a/src/main/java/flab/transtalk/user/service/profile/ProfileService.java
+++ b/src/main/java/flab/transtalk/user/service/profile/ProfileService.java
@@ -4,22 +4,19 @@ import flab.transtalk.common.exception.NotFoundException;
 import flab.transtalk.common.exception.message.ExceptionMessages;
 import flab.transtalk.user.domain.Profile;
 import flab.transtalk.user.dto.req.ProfileUpdateRequestDto;
-import flab.transtalk.user.dto.res.PostResponseDto;
 import flab.transtalk.user.dto.res.ProfileResponseDto;
 import flab.transtalk.user.repository.ProfileRepository;
-import flab.transtalk.user.service.post.PostService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.List;
 
 @Service
 @RequiredArgsConstructor
 public class ProfileService {
 
     private final ProfileRepository profileRepository;
-    private final PostService postService;
+    private final ProfileDtoMapper profileDtoMapper;
 
     @Transactional
     public ProfileResponseDto updateProfile(Long profileId, ProfileUpdateRequestDto dto){
@@ -42,7 +39,7 @@ public class ProfileService {
             profile.setLanguage(dto.getLanguage());
         }
 
-        return ProfileResponseDto.from(profile);
+        return profileDtoMapper.toDto(profile);
     }
 
     @Transactional(readOnly = true)
@@ -53,11 +50,6 @@ public class ProfileService {
                         profileId.toString()
                 ));
 
-        ProfileResponseDto res = ProfileResponseDto.from(profile);
-        List<PostResponseDto> posts = postService.getPosts(profile.getPosts());
-        res.getPosts().addAll(posts);
-
-        return res;
+        return profileDtoMapper.toDto(profile);
     }
-
 }

--- a/src/main/java/flab/transtalk/user/service/profile/ProfileService.java
+++ b/src/main/java/flab/transtalk/user/service/profile/ProfileService.java
@@ -1,14 +1,19 @@
 package flab.transtalk.user.service.profile;
 
+import flab.transtalk.common.exception.BadRequestException;
 import flab.transtalk.common.exception.NotFoundException;
 import flab.transtalk.common.exception.message.ExceptionMessages;
 import flab.transtalk.user.domain.Profile;
 import flab.transtalk.user.dto.req.ProfileUpdateRequestDto;
 import flab.transtalk.user.dto.res.ProfileResponseDto;
 import flab.transtalk.user.repository.ProfileRepository;
+import flab.transtalk.user.service.image.S3Service;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
 
 
 @Service
@@ -17,6 +22,7 @@ public class ProfileService {
 
     private final ProfileRepository profileRepository;
     private final ProfileDtoMapper profileDtoMapper;
+    private final S3Service s3Service;
 
     @Transactional
     public ProfileResponseDto updateProfile(Long profileId, ProfileUpdateRequestDto dto){
@@ -49,6 +55,29 @@ public class ProfileService {
                         ExceptionMessages.PROFILE_NOT_FOUND,
                         profileId.toString()
                 ));
+
+        return profileDtoMapper.toDto(profile);
+    }
+
+    @Transactional
+    public ProfileResponseDto updateProfileImage(Long profileId, MultipartFile imageFile) {
+        Profile profile = profileRepository.findById(profileId)
+                .orElseThrow(() -> new NotFoundException(
+                        ExceptionMessages.PROFILE_NOT_FOUND,
+                        profileId.toString()
+                ));
+        Long userId = profile.getUser().getId();
+        String prevImageKey = profile.getImageKey();
+        String generatedImageKey;
+        try {
+            generatedImageKey = s3Service.uploadProfileImageFile(imageFile, userId);
+        } catch (IOException e) {
+            throw new BadRequestException(ExceptionMessages.IMAGE_UPLOAD_FAILED);
+        }
+        profile.setImageKey(generatedImageKey);
+        if (prevImageKey!=null){
+            s3Service.deleteImageFile(prevImageKey);
+        }
 
         return profileDtoMapper.toDto(profile);
     }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -75,3 +75,12 @@ app:
     s3:
       bucket: ${AWS_S3_POST_BUCKET}     # 이미지 저장 버킷
       region: ${AWS_S3_REGION}
+      profiles-resource-path: user-profile-images/
+      post-resource-path: user-post-images/
+    cloudfront:
+      domain: ${AWS_CLOUDFRONT_DOMAIN}
+      key-pair-id: ${AWS_CLOUDFRONT_KEY_PAIR_ID}
+      private-key-path: ${AWS_CLOUDFRONT_PRIVATE_KEY_PATH}
+      resource-paths:
+        - user-profile-images/*
+        - user-post-images/*

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -77,6 +77,9 @@ app:
       region: ${AWS_S3_REGION}
       profiles-resource-path: user-profile-images/
       post-resource-path: user-post-images/
+      suffix:
+        large: -large
+        small: -small
     cloudfront:
       domain: ${AWS_CLOUDFRONT_DOMAIN}
       key-pair-id: ${AWS_CLOUDFRONT_KEY_PAIR_ID}


### PR DESCRIPTION
## 작업 내용
- Issue 수행
    - #9 
    - #16

## 유의
- profile과 post의 각 entity to dto 과정에서 특정 service bean을 주입받아야 하는 상황이 발생하여, 의존성 관리를 위해 각각 별도의 DTO Mapper를 정의하여 사용하였다.
- CloudFront + Signed Cookie 사용의 가장 큰 목적은, 이미지 요청 URL에 인증 파라미터를 포함하지 않도록 구성하여 웹 브라우저의 캐시 활용이 원활하게 이뤄질 수 있도록 하는 것이다.
- 이미지의 large 버전과 small 버전을 각각 구성하여 웹 클라이언트에서 상황에 맞는 적절한 크기의 이미지를 불러올 수 있도록 구성하였다.