### PR TITLE
[#10] 웹소켓을 사용한 실시간 채팅 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,6 +33,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+	implementation 'org.springframework.boot:spring-boot-starter-websocket'
 
 	// S3
 	implementation platform("software.amazon.awssdk:bom:${awsSdkVersion}")   	// SDK v2 BOM – 다중 모듈 버전 통일

--- a/src/main/java/flab/transtalk/auth/config/SecurityConfig.java
+++ b/src/main/java/flab/transtalk/auth/config/SecurityConfig.java
@@ -31,7 +31,7 @@ public class SecurityConfig {
                 .csrf(csrf -> csrf.disable())
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers("/", "/oauth2/**", "/login/**").permitAll()
+                        .requestMatchers("/", "/oauth2/**", "/login/**", "/ws-chat/**", "/h2-console/**").permitAll()
                         .anyRequest().authenticated()
                 )
                 .oauth2Login(oauth2 -> oauth2

--- a/src/main/java/flab/transtalk/auth/config/WebSocketConfig.java
+++ b/src/main/java/flab/transtalk/auth/config/WebSocketConfig.java
@@ -1,0 +1,55 @@
+package flab.transtalk.auth.config;
+
+import flab.transtalk.auth.security.jwt.JwtHandshakeInterceptor;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.simp.config.ChannelRegistration;
+import org.springframework.messaging.simp.config.MessageBrokerRegistry;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.messaging.support.ChannelInterceptor;
+import org.springframework.messaging.support.MessageHeaderAccessor;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
+import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
+import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
+
+@Configuration
+@EnableWebSocketMessageBroker
+@RequiredArgsConstructor
+public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
+
+    private final JwtHandshakeInterceptor jwtHandshakeInterceptor;
+
+    @Override
+    public void registerStompEndpoints(StompEndpointRegistry registry) {
+        registry.addEndpoint("/ws-chat")
+                .setAllowedOriginPatterns("*")
+                .addInterceptors(jwtHandshakeInterceptor)
+                .withSockJS(); // for browser fallback
+    }
+
+    @Override
+    public void configureMessageBroker(MessageBrokerRegistry registry) {
+        registry.enableSimpleBroker("/topic", "/queue");
+        registry.setApplicationDestinationPrefixes("/app");
+    }
+
+    @Override
+    public void configureClientInboundChannel(ChannelRegistration registration) {
+        registration.interceptors(new ChannelInterceptor() {
+            @Override
+            public Message<?> preSend(Message<?> message, MessageChannel channel) {
+                StompHeaderAccessor accessor = MessageHeaderAccessor.getAccessor(message, StompHeaderAccessor.class);
+                if (accessor != null && accessor.getUser() == null) {
+                    SecurityContext context = (SecurityContext) accessor.getSessionAttributes().get("SPRING_SECURITY_CONTEXT");
+                    if (context != null) {
+                        accessor.setUser(context.getAuthentication());
+                    }
+                }
+                return message;
+            }
+        });
+    }
+}

--- a/src/main/java/flab/transtalk/auth/config/WebSocketConfig.java
+++ b/src/main/java/flab/transtalk/auth/config/WebSocketConfig.java
@@ -1,12 +1,16 @@
 package flab.transtalk.auth.config;
 
 import flab.transtalk.auth.security.jwt.JwtHandshakeInterceptor;
+import flab.transtalk.common.exception.NotFoundException;
+import flab.transtalk.translation.service.chatroom.ChatRoomService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.MessagingException;
 import org.springframework.messaging.simp.config.ChannelRegistration;
 import org.springframework.messaging.simp.config.MessageBrokerRegistry;
+import org.springframework.messaging.simp.stomp.StompCommand;
 import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
 import org.springframework.messaging.support.ChannelInterceptor;
 import org.springframework.messaging.support.MessageHeaderAccessor;
@@ -15,12 +19,15 @@ import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBr
 import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
 import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
 
+import java.security.Principal;
+
 @Configuration
 @EnableWebSocketMessageBroker
 @RequiredArgsConstructor
 public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
 
     private final JwtHandshakeInterceptor jwtHandshakeInterceptor;
+    private final ChatRoomService chatRoomService;
 
     @Override
     public void registerStompEndpoints(StompEndpointRegistry registry) {
@@ -42,12 +49,32 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
             @Override
             public Message<?> preSend(Message<?> message, MessageChannel channel) {
                 StompHeaderAccessor accessor = MessageHeaderAccessor.getAccessor(message, StompHeaderAccessor.class);
-                if (accessor != null && accessor.getUser() == null) {
-                    SecurityContext context = (SecurityContext) accessor.getSessionAttributes().get("SPRING_SECURITY_CONTEXT");
-                    if (context != null) {
-                        accessor.setUser(context.getAuthentication());
+                if (accessor != null){
+                    if (accessor.getUser() == null) {
+                        SecurityContext context = (SecurityContext) accessor.getSessionAttributes().get("SPRING_SECURITY_CONTEXT");
+                        if (context != null) {
+                            accessor.setUser(context.getAuthentication());
+                        }
+                    }
+                    if (StompCommand.SUBSCRIBE.equals(accessor.getCommand())) {
+                        String destination = accessor.getDestination();
+                        Principal user = accessor.getUser();
+
+                        if (destination == null || !destination.startsWith("/topic/chat-room.") || destination.length()=="/topic/chat-room.".length()) {
+                            throw new MessagingException("잘못된 구독 경로입니다.");
+                        }
+                        Long chatRoomId = Long.valueOf(destination.substring("/topic/chat-room.".length()));
+                        Long userId = Long.valueOf(user.getName());
+                        try {
+                            if (!chatRoomService.isParticipant(userId, chatRoomId)) {
+                                throw new MessagingException("구독 권한이 없습니다.");
+                            }
+                        } catch (NotFoundException ex){
+                            throw new MessagingException("존재하지 않는 채팅방입니다.");
+                        }
                     }
                 }
+
                 return message;
             }
         });

--- a/src/main/java/flab/transtalk/auth/security/jwt/JwtHandshakeInterceptor.java
+++ b/src/main/java/flab/transtalk/auth/security/jwt/JwtHandshakeInterceptor.java
@@ -1,0 +1,62 @@
+package flab.transtalk.auth.security.jwt;
+
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.server.ServerHttpRequest;
+import org.springframework.http.server.ServerHttpResponse;
+import org.springframework.http.server.ServletServerHttpRequest;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextImpl;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.stereotype.Component;
+import org.springframework.web.socket.WebSocketHandler;
+import org.springframework.web.socket.server.HandshakeInterceptor;
+
+import java.util.Map;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class JwtHandshakeInterceptor implements HandshakeInterceptor {
+
+    private final JwtTokenProvider jwtTokenProvider;
+    private final UserDetailsService userDetailsService;
+
+    @Override
+    public boolean beforeHandshake(ServerHttpRequest request, ServerHttpResponse response,
+                                   WebSocketHandler wsHandler, Map<String, Object> attributes) {
+        if (!(request instanceof ServletServerHttpRequest servletRequest)) {
+            return false;
+        }
+            HttpServletRequest httpServletRequest = servletRequest.getServletRequest();
+            String token = resolveToken(httpServletRequest);
+
+        if (token == null || !jwtTokenProvider.validateToken(token)) {
+            return false;
+        }
+
+        String subject = jwtTokenProvider.getSubject(token);
+        UserDetails userDetails = userDetailsService.loadUserByUsername(subject);
+        UsernamePasswordAuthenticationToken authentication =
+                new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
+        attributes.put("SPRING_SECURITY_CONTEXT", new SecurityContextImpl(authentication));
+        return true;
+    }
+
+    @Override
+    public void afterHandshake(ServerHttpRequest request, ServerHttpResponse response,
+                               WebSocketHandler wsHandler, Exception exception) {
+        if (exception == null) {
+            log.info("WebSocket 핸드셰이크 성공: {}", request.getRemoteAddress());
+        } else {
+            log.warn("WebSocket 핸드셰이크 실패", exception);
+        }
+    }
+
+    private String resolveToken(HttpServletRequest request) {
+        String token = request.getParameter("token");
+        return (token != null && token.startsWith("Bearer ")) ? token.substring(7) : null;
+    }
+}

--- a/src/main/java/flab/transtalk/auth/security/jwt/JwtTokenProvider.java
+++ b/src/main/java/flab/transtalk/auth/security/jwt/JwtTokenProvider.java
@@ -64,4 +64,13 @@ public class JwtTokenProvider {
             throw new JwtAuthenticationException(JwtErrorCode.INVALID_SIGNATURE, e);
         }
     }
+
+    public boolean validateToken(String token) {
+        try {
+            parseClaims(token);
+            return true;
+        } catch (JwtAuthenticationException e) {
+            return false;
+        }
+    }
 }

--- a/src/main/java/flab/transtalk/auth/security/principal/CustomUserDetails.java
+++ b/src/main/java/flab/transtalk/auth/security/principal/CustomUserDetails.java
@@ -11,14 +11,7 @@ import org.springframework.security.core.GrantedAuthority;
 public class CustomUserDetails implements UserDetails {
 
     private final Long userId;                          // userId
-    private final String username;                      // JWT subject
     private final Collection<? extends GrantedAuthority> authorities;
-
-    public CustomUserDetails(Long userId, String username, Collection<? extends GrantedAuthority> authorities) {
-        this.userId = userId;
-        this.username = username;
-        this.authorities = authorities;
-    }
 
     public Long getUserId(){
         return userId;
@@ -26,7 +19,7 @@ public class CustomUserDetails implements UserDetails {
 
     @Override public Collection<? extends GrantedAuthority> getAuthorities() { return authorities; }
     @Override public String getPassword() { return ""; }      // 소셜 로그인
-    @Override public String getUsername() { return username; }
+    @Override public String getUsername() { return String.valueOf(getUserId()); }
     @Override public boolean isAccountNonExpired() { return true; }
     @Override public boolean isAccountNonLocked() { return true; }
     @Override public boolean isCredentialsNonExpired() { return true; }

--- a/src/main/java/flab/transtalk/auth/service/CustomUserDetailsService.java
+++ b/src/main/java/flab/transtalk/auth/service/CustomUserDetailsService.java
@@ -28,7 +28,6 @@ public class CustomUserDetailsService implements UserDetailsService {
 
         return CustomUserDetails.builder()
                 .userId(user.getId())
-                .username(externalId)
                 .authorities(Collections.singleton(new SimpleGrantedAuthority(DEFAULT_ROLE)))
                 .build();
     }

--- a/src/main/java/flab/transtalk/common/exception/message/ExceptionMessages.java
+++ b/src/main/java/flab/transtalk/common/exception/message/ExceptionMessages.java
@@ -7,6 +7,8 @@ public class ExceptionMessages {
     public static final String PROFILE_NOT_FOUND = "존재하지 않는 프로필입니다.";
     public static final String POST_NOT_FOUND = "존재하지 않는 포스트입니다.";
     public static final String IMAGE_NOT_FOUND = "존재하지 않는 이미지입니다.";
+    public static final String USER_NOT_FOUND_IN_CHATROOM = "채팅방에 존재하지 않는 사용자입니다.";
+    public static final String CHATROOM_NOT_FOUND = "존재하지 않는 채팅방입니다.";
 
 
     // BadRequestException

--- a/src/main/java/flab/transtalk/translation/controller/ChatMessageController.java
+++ b/src/main/java/flab/transtalk/translation/controller/ChatMessageController.java
@@ -1,0 +1,30 @@
+package flab.transtalk.translation.controller;
+
+import flab.transtalk.translation.dto.req.ChatMessageRequestDto;
+import flab.transtalk.translation.dto.res.ChatMessageResponseDto;
+import flab.transtalk.translation.service.chatmessage.ChatMessageService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.messaging.handler.annotation.MessageMapping;
+import org.springframework.messaging.handler.annotation.Payload;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.stereotype.Controller;
+
+import java.security.Principal;
+
+@Controller
+@RequiredArgsConstructor
+public class ChatMessageController {
+
+    private final SimpMessagingTemplate messagingTemplate;
+    private final ChatMessageService chatMessageService;
+
+    @MessageMapping("/chat.send")
+    public void sendMessage(@Payload ChatMessageRequestDto messageRequest,
+                            Principal principal) {
+        Long senderId = Long.parseLong(principal.getName());
+        ChatMessageResponseDto response = chatMessageService.saveMessage(messageRequest, senderId);
+
+        String destination = "/topic/chat-room." + response.getChatRoomId();
+        messagingTemplate.convertAndSend(destination, response);
+    }
+}

--- a/src/main/java/flab/transtalk/translation/domain/ChatMessage.java
+++ b/src/main/java/flab/transtalk/translation/domain/ChatMessage.java
@@ -1,0 +1,39 @@
+package flab.transtalk.translation.domain;
+
+import flab.transtalk.user.domain.User;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class ChatMessage {
+    @Id
+    @GeneratedValue(strategy = GenerationType.SEQUENCE)
+    @SequenceGenerator(
+        name = "chat_record_seq_gen",
+        sequenceName = "chat_record_seq"
+    )
+    private Long id;
+
+    @Column
+    private String content;
+
+    @Column
+    private String translatedText;
+
+    @Column
+    private LocalDateTime createdDate;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "chat_room_id")
+    private ChatRoom chatRoom;
+}

--- a/src/main/java/flab/transtalk/translation/domain/ChatRoom.java
+++ b/src/main/java/flab/transtalk/translation/domain/ChatRoom.java
@@ -29,6 +29,10 @@ public class ChatRoom {
     @Builder.Default
     private List<ChatRoomUser> chatRoomUsers = new ArrayList<>();
 
+    @OneToMany(mappedBy = "chatRoom", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
+    @Builder.Default
+    private List<ChatMessage> chatMessages = new ArrayList<>();
+
     public void addUser(User user) {
         ChatRoomUser chatRoomUser = ChatRoomUser.builder()
                 .chatRoom(this)

--- a/src/main/java/flab/transtalk/translation/dto/req/ChatMessageRequestDto.java
+++ b/src/main/java/flab/transtalk/translation/dto/req/ChatMessageRequestDto.java
@@ -1,0 +1,9 @@
+package flab.transtalk.translation.dto.req;
+
+import lombok.Value;
+
+@Value
+public class ChatMessageRequestDto {
+    Long chatRoomId;
+    String content;
+}

--- a/src/main/java/flab/transtalk/translation/dto/res/ChatMessageResponseDto.java
+++ b/src/main/java/flab/transtalk/translation/dto/res/ChatMessageResponseDto.java
@@ -1,0 +1,34 @@
+package flab.transtalk.translation.dto.res;
+
+import flab.transtalk.translation.domain.ChatMessage;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Value;
+
+import java.time.LocalDateTime;
+
+@Value
+@Builder
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class ChatMessageResponseDto {
+    Long chatRoomId;
+    Long senderId;
+    String content;
+    String translatedText;
+    LocalDateTime createdDate;
+
+    public static ChatMessageResponseDto from(ChatMessage chatMessage) {
+        return ChatMessageResponseDto.builder()
+                .chatRoomId(chatMessage.getChatRoom()!=null?
+                        chatMessage.getChatRoom().getId() :
+                        null
+                ).senderId(chatMessage.getUser()!=null?
+                        chatMessage.getUser().getId() :
+                        null
+                ).content(chatMessage.getContent())
+                .translatedText(chatMessage.getTranslatedText())
+                .createdDate(chatMessage.getCreatedDate())
+                .build();
+    }
+}

--- a/src/main/java/flab/transtalk/translation/repository/ChatMessageRepository.java
+++ b/src/main/java/flab/transtalk/translation/repository/ChatMessageRepository.java
@@ -1,0 +1,7 @@
+package flab.transtalk.translation.repository;
+
+import flab.transtalk.translation.domain.ChatMessage;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long> {
+}

--- a/src/main/java/flab/transtalk/translation/service/chatmessage/ChatMessageService.java
+++ b/src/main/java/flab/transtalk/translation/service/chatmessage/ChatMessageService.java
@@ -1,0 +1,62 @@
+package flab.transtalk.translation.service.chatmessage;
+
+import flab.transtalk.common.exception.NotFoundException;
+import flab.transtalk.common.exception.message.ExceptionMessages;
+import flab.transtalk.translation.domain.ChatMessage;
+import flab.transtalk.translation.domain.ChatRoom;
+import flab.transtalk.translation.dto.req.ChatMessageRequestDto;
+import flab.transtalk.translation.dto.res.ChatMessageResponseDto;
+import flab.transtalk.translation.repository.ChatMessageRepository;
+import flab.transtalk.translation.repository.ChatRoomRepository;
+import flab.transtalk.user.domain.User;
+import flab.transtalk.user.repository.UserRepository;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+
+@Service
+@RequiredArgsConstructor
+public class ChatMessageService {
+
+    private final UserRepository userRepository;
+    private final ChatRoomRepository chatRoomRepository;
+    private final ChatMessageRepository chatMessageRepository;
+
+    @Transactional
+    public ChatMessageResponseDto saveMessage(ChatMessageRequestDto request, Long senderId) {
+        ChatRoom chatRoom = chatRoomRepository.findById(request.getChatRoomId())
+                .orElseThrow(() -> new NotFoundException(
+                        ExceptionMessages.CHATROOM_NOT_FOUND,
+                        request.getChatRoomId().toString()
+                ));
+
+        User sender = userRepository.findById(senderId)
+                .orElseThrow(() -> new NotFoundException(
+                        ExceptionMessages.USER_NOT_FOUND,
+                        senderId.toString()
+                ));
+
+        boolean isParticipant = chatRoom.getChatRoomUsers().stream()
+                .anyMatch(chatRoomUser -> chatRoomUser.getUser().getId().equals(senderId));
+        if (!isParticipant) {
+            throw new NotFoundException(
+                    ExceptionMessages.USER_NOT_FOUND_IN_CHATROOM,
+                    senderId.toString()
+            );
+        }
+
+        ChatMessage chatMessage = ChatMessage.builder()
+                .chatRoom(chatRoom)
+                .user(sender)
+                .content(request.getContent())
+                .translatedText(null)
+                .createdDate(LocalDateTime.now())
+                .build();
+
+        chatMessageRepository.save(chatMessage);
+
+        return ChatMessageResponseDto.from(chatMessage);
+    }
+}

--- a/src/main/java/flab/transtalk/translation/service/chatroom/ChatRoomService.java
+++ b/src/main/java/flab/transtalk/translation/service/chatroom/ChatRoomService.java
@@ -4,7 +4,6 @@ import flab.transtalk.common.exception.BadRequestException;
 import flab.transtalk.common.exception.NotFoundException;
 import flab.transtalk.common.exception.message.ExceptionMessages;
 import flab.transtalk.translation.domain.ChatRoom;
-import flab.transtalk.translation.domain.ChatRoomUser;
 import flab.transtalk.translation.dto.req.ChatRoomCreateRequestDto;
 import flab.transtalk.translation.dto.res.ChatRoomResponseDto;
 import flab.transtalk.translation.repository.ChatRoomRepository;
@@ -16,7 +15,6 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Arrays;
 import java.util.List;
-import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -47,4 +45,15 @@ public class ChatRoomService {
         return ChatRoomResponseDto.from(savedChatRoom);
     }
 
+    @Transactional(readOnly = true)
+    public boolean isParticipant(Long userId, Long chatRoomId) {
+        ChatRoom chatRoom = chatRoomRepository.findById(chatRoomId)
+                .orElseThrow(() -> new NotFoundException(
+                        ExceptionMessages.CHATROOM_NOT_FOUND,
+                        chatRoomId.toString()
+                ));
+
+        return chatRoom.getChatRoomUsers().stream()
+                .anyMatch(chatRoomUser -> chatRoomUser.getUser().getId().equals(userId));
+    }
 }

--- a/src/main/java/flab/transtalk/user/domain/User.java
+++ b/src/main/java/flab/transtalk/user/domain/User.java
@@ -1,6 +1,7 @@
 package flab.transtalk.user.domain;
 
 import flab.transtalk.auth.domain.AuthAccount;
+import flab.transtalk.translation.domain.ChatMessage;
 import flab.transtalk.translation.domain.ChatRoomUser;
 import jakarta.persistence.*;
 import java.util.ArrayList;
@@ -43,6 +44,9 @@ public class User {
 
     @OneToOne(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
     private AuthAccount authAccount;
+
+    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
+    private List<ChatMessage> chatMessages = new ArrayList<>();
 
     @Builder
     private User(String email) {


### PR DESCRIPTION
## 작업 내용
- Issue 수행
    - #10 

## 유의
- 실시간 채팅 기능을 지원하기 위해 WebSocket 구성 및 메시지 처리 로직을 추가하였다.
- JWT 인증 기반 WebSocket 연결 보호를위해 핸드셰이크 과정에서 토큰을 검증하는 인터셉터를 추가하였다.
- 채팅방 구독 요청이 들어왔을 때, SUBSCRIBE 커맨드가 preSend될 때(구독 등록 전) 사용자가 해당 채팅방의 참여자인지를 확인하여 구독 승인 여부를 관리하였다.

## WebSocket 및 메시지 처리 로직 시퀀스다이어그램
<img width="1059" alt="image" src="https://github.com/user-attachments/assets/336d1010-1c88-4bde-975a-3e445de48fdb" />
