### PR TITLE
[#11] 번역 서비스 로직 구현 및 채팅 서비스와 연계

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -412,5 +412,6 @@ build/
 # key
 *.pem
 *.p12
+*.json
 
 # End of https://www.toptal.com/developers/gitignore/api/macos,intellij,java,python,netbeans,visualstudiocode

--- a/build.gradle
+++ b/build.gradle
@@ -45,6 +45,9 @@ dependencies {
 	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
 	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
 	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+	
+	// Google
+	implementation 'com.google.auth:google-auth-library-oauth2-http:1.19.0'
 
 	implementation 'org.springframework.boot:spring-boot-configuration-processor'
 	annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'

--- a/src/main/java/flab/transtalk/common/enums/LanguageSelection.java
+++ b/src/main/java/flab/transtalk/common/enums/LanguageSelection.java
@@ -1,5 +1,18 @@
 package flab.transtalk.common.enums;
 
 public enum LanguageSelection {
-    KOR, ENG
+    KOR("ko"),
+    ENG("en"),
+    JPN("ja");
+
+
+    private final String code;
+
+    private LanguageSelection(String code){
+        this.code = code;
+    };
+
+    public String getCode(){
+        return this.code;
+    }
 }

--- a/src/main/java/flab/transtalk/common/enums/TranslationProviderSelection.java
+++ b/src/main/java/flab/transtalk/common/enums/TranslationProviderSelection.java
@@ -1,0 +1,15 @@
+package flab.transtalk.common.enums;
+
+public enum TranslationProviderSelection {
+    GOOGLE("google");
+
+    private final String providerKey;
+
+    private TranslationProviderSelection(String providerKey){
+        this.providerKey = providerKey;
+    }
+
+    public String getProviderKey(){
+        return this.providerKey;
+    }
+}

--- a/src/main/java/flab/transtalk/common/exception/ExternalApiUnavailableException.java
+++ b/src/main/java/flab/transtalk/common/exception/ExternalApiUnavailableException.java
@@ -1,0 +1,7 @@
+package flab.transtalk.common.exception;
+
+public class ExternalApiUnavailableException extends RuntimeException{
+    public ExternalApiUnavailableException(String message){
+        super(message);
+    }
+}

--- a/src/main/java/flab/transtalk/common/exception/MissingMandatoryAssociationException.java
+++ b/src/main/java/flab/transtalk/common/exception/MissingMandatoryAssociationException.java
@@ -1,0 +1,7 @@
+package flab.transtalk.common.exception;
+
+public class MissingMandatoryAssociationException extends RuntimeException {
+    public MissingMandatoryAssociationException(String message){
+        super(message);
+    }
+}

--- a/src/main/java/flab/transtalk/common/exception/handler/CustomExceptionHandler.java
+++ b/src/main/java/flab/transtalk/common/exception/handler/CustomExceptionHandler.java
@@ -3,6 +3,7 @@ package flab.transtalk.common.exception.handler;
 import flab.transtalk.common.dto.res.ApiErrorResponse;
 import flab.transtalk.common.exception.BadRequestException;
 import flab.transtalk.common.exception.NotFoundException;
+import flab.transtalk.common.exception.MissingMandatoryAssociationException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -28,5 +29,11 @@ public class CustomExceptionHandler {
         List<String> errors = new ArrayList<>();
         errors.add(e.getMessage());
         return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(new ApiErrorResponse("BAD_REQUEST", errors));
+    }
+    @ExceptionHandler(MissingMandatoryAssociationException.class)
+    public ResponseEntity<ApiErrorResponse> handlerMissingMandatoryAssociationException(MissingMandatoryAssociationException e){
+        List<String> errors = new ArrayList<>();
+        errors.add(e.getMessage());
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(new ApiErrorResponse("INTERNAL_SERVER_ERROR", errors));
     }
 }

--- a/src/main/java/flab/transtalk/common/exception/handler/CustomExceptionHandler.java
+++ b/src/main/java/flab/transtalk/common/exception/handler/CustomExceptionHandler.java
@@ -2,6 +2,7 @@ package flab.transtalk.common.exception.handler;
 
 import flab.transtalk.common.dto.res.ApiErrorResponse;
 import flab.transtalk.common.exception.BadRequestException;
+import flab.transtalk.common.exception.ExternalApiUnavailableException;
 import flab.transtalk.common.exception.NotFoundException;
 import flab.transtalk.common.exception.MissingMandatoryAssociationException;
 import org.springframework.http.HttpStatus;
@@ -32,6 +33,12 @@ public class CustomExceptionHandler {
     }
     @ExceptionHandler(MissingMandatoryAssociationException.class)
     public ResponseEntity<ApiErrorResponse> handlerMissingMandatoryAssociationException(MissingMandatoryAssociationException e){
+        List<String> errors = new ArrayList<>();
+        errors.add(e.getMessage());
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(new ApiErrorResponse("INTERNAL_SERVER_ERROR", errors));
+    }
+    @ExceptionHandler(ExternalApiUnavailableException.class)
+    public ResponseEntity<ApiErrorResponse> handlerExternalApiUnavailableException(ExternalApiUnavailableException e){
         List<String> errors = new ArrayList<>();
         errors.add(e.getMessage());
         return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(new ApiErrorResponse("INTERNAL_SERVER_ERROR", errors));

--- a/src/main/java/flab/transtalk/common/exception/message/ExceptionMessages.java
+++ b/src/main/java/flab/transtalk/common/exception/message/ExceptionMessages.java
@@ -24,4 +24,8 @@ public class ExceptionMessages {
     public static final String PROFILE_NOT_LINKED_TO_USER = "사용자에게 프로필이 링크되지 않은 상태입니다.";
 
 
+    // ExternalApiUnavailableException
+    public static final String TRANSLATION_SERVICE_UNAVAILABLE = "해당 외부 번역 API가 현재 사용이 불가능한 상태입니다. 다음에 다시 요청해주시길 바랍니다.: %s";
+
+
 }

--- a/src/main/java/flab/transtalk/common/exception/message/ExceptionMessages.java
+++ b/src/main/java/flab/transtalk/common/exception/message/ExceptionMessages.java
@@ -17,4 +17,11 @@ public class ExceptionMessages {
     public static final String UNSUPPORTED_IMAGE_FORMAT = "지원하지 않는 이미지 형식입니다: %s";
     public static final String USER_MATCH_STATUS_NOT_FOUND = "사용자의 매칭 상태 정보가 존재하지 않습니다.";
     public static final String MATCH_ATTEMPT_EXHAUSTED = "남은 매칭 시도 가능 횟수가 없습니다.";
+
+
+    // RequiredRelationMissingException
+    public static final String NOT_EXIST_RECEIVER_IN_CHATROOM = "채팅방에 대화 상대가 존재하지 않습니다.";
+    public static final String PROFILE_NOT_LINKED_TO_USER = "사용자에게 프로필이 링크되지 않은 상태입니다.";
+
+
 }

--- a/src/main/java/flab/transtalk/config/GoogleConfig.java
+++ b/src/main/java/flab/transtalk/config/GoogleConfig.java
@@ -1,0 +1,27 @@
+package flab.transtalk.config;
+
+import com.google.auth.oauth2.GoogleCredentials;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+
+@Configuration
+public class GoogleConfig {
+    @Value(("${translation.google.credentials-path}"))
+    private String credentialsPath;
+
+    @Bean
+    public GoogleCredentials googleCredentials(){
+        try (InputStream inputStream = new FileInputStream(credentialsPath)) {
+            return GoogleCredentials
+                    .fromStream(inputStream)
+                    .createScoped("https://www.googleapis.com/auth/cloud-platform");
+        } catch (IOException e) {
+            throw new IllegalStateException("Google 서비스 계정 키 로딩 실패", e);
+        }
+    }
+}

--- a/src/main/java/flab/transtalk/translation/domain/ChatMessage.java
+++ b/src/main/java/flab/transtalk/translation/domain/ChatMessage.java
@@ -21,10 +21,10 @@ public class ChatMessage {
     )
     private Long id;
 
-    @Column
+    @Column(nullable = false)
     private String content;
 
-    @Column
+    @Column(nullable = false)
     private String translatedText;
 
     @Column

--- a/src/main/java/flab/transtalk/translation/dto/req/ChatMessageRequestDto.java
+++ b/src/main/java/flab/transtalk/translation/dto/req/ChatMessageRequestDto.java
@@ -1,9 +1,11 @@
 package flab.transtalk.translation.dto.req;
 
+import flab.transtalk.common.enums.TranslationProviderSelection;
 import lombok.Getter;
 
 @Getter
 public class ChatMessageRequestDto {
     private Long chatRoomId;
     private String content;
+    private TranslationProviderSelection providerSelection = TranslationProviderSelection.GOOGLE;
 }

--- a/src/main/java/flab/transtalk/translation/service/chatmessage/ChatMessageService.java
+++ b/src/main/java/flab/transtalk/translation/service/chatmessage/ChatMessageService.java
@@ -1,6 +1,8 @@
 package flab.transtalk.translation.service.chatmessage;
 
+import flab.transtalk.common.exception.ExternalApiUnavailableException;
 import flab.transtalk.common.exception.NotFoundException;
+import flab.transtalk.common.exception.MissingMandatoryAssociationException;
 import flab.transtalk.common.exception.message.ExceptionMessages;
 import flab.transtalk.translation.domain.ChatMessage;
 import flab.transtalk.translation.domain.ChatRoom;
@@ -9,6 +11,8 @@ import flab.transtalk.translation.dto.res.ChatMessageResponseDto;
 import flab.transtalk.translation.repository.ChatMessageRepository;
 import flab.transtalk.translation.repository.ChatRoomRepository;
 import flab.transtalk.translation.service.chatroom.ChatRoomService;
+import flab.transtalk.translation.service.translation.TranslateService;
+import flab.transtalk.user.domain.Profile;
 import flab.transtalk.user.domain.User;
 import flab.transtalk.user.repository.UserRepository;
 import jakarta.transaction.Transactional;
@@ -25,6 +29,7 @@ public class ChatMessageService {
     private final ChatRoomRepository chatRoomRepository;
     private final ChatMessageRepository chatMessageRepository;
     private final ChatRoomService chatRoomService;
+    private final TranslateService translateService;
 
     @Transactional
     public ChatMessageResponseDto saveMessage(ChatMessageRequestDto request, Long senderId) {
@@ -48,11 +53,47 @@ public class ChatMessageService {
             );
         }
 
+        Profile senderProfile = sender.getProfile();
+        if (senderProfile == null){
+            throw new MissingMandatoryAssociationException(
+                    ExceptionMessages.PROFILE_NOT_LINKED_TO_USER
+            );
+        }
+
+        User receiverUser = chatRoom.getChatRoomUsers().stream().filter(target->target.getId().equals(sender.getId())).findFirst()
+                .orElseThrow(() -> new MissingMandatoryAssociationException(
+                        ExceptionMessages.NOT_EXIST_RECEIVER_IN_CHATROOM
+                )).getUser();
+        Profile receiverProfile = receiverUser.getProfile();
+        if (receiverProfile == null){
+            throw new MissingMandatoryAssociationException(
+                    ExceptionMessages.PROFILE_NOT_LINKED_TO_USER
+            );
+        }
+
+        String translatedText;
+        try {
+            translatedText = translateService.translate(
+                    request.getProviderSelection(),
+                    request.getContent(),
+                    senderProfile.getLanguage(),
+                    receiverProfile.getLanguage()
+            );
+        } catch(IllegalArgumentException ex) {
+            throw ex;
+        } catch(RuntimeException ex) {
+            throw new ExternalApiUnavailableException(
+                    String.format(
+                            ExceptionMessages.TRANSLATION_SERVICE_UNAVAILABLE,
+                            request.getProviderSelection().getProviderKey()
+                    ));
+        }
+
         ChatMessage chatMessage = ChatMessage.builder()
                 .chatRoom(chatRoom)
                 .user(sender)
                 .content(request.getContent())
-                .translatedText(null)
+                .translatedText(translatedText)
                 .createdDate(LocalDateTime.now())
                 .build();
 

--- a/src/main/java/flab/transtalk/translation/service/translation/GoogleTranslationProvider.java
+++ b/src/main/java/flab/transtalk/translation/service/translation/GoogleTranslationProvider.java
@@ -34,7 +34,6 @@ public class GoogleTranslationProvider implements TranslationProvider {
         headers.setContentType(MediaType.APPLICATION_JSON);
 
         Map<String, Object> requestBody = Map.of(
-                "sourceLanguageCode", sourceLang.getCode(),
                 "targetLanguageCode", targetLang.getCode(),
                 "contents", Collections.singletonList(text)
         );

--- a/src/main/java/flab/transtalk/translation/service/translation/GoogleTranslationProvider.java
+++ b/src/main/java/flab/transtalk/translation/service/translation/GoogleTranslationProvider.java
@@ -1,0 +1,76 @@
+package flab.transtalk.translation.service.translation;
+
+import com.google.auth.oauth2.GoogleCredentials;
+import flab.transtalk.common.enums.LanguageSelection;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.*;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+@Component("google")
+@RequiredArgsConstructor
+@Slf4j
+public class GoogleTranslationProvider implements TranslationProvider {
+
+    private final RestTemplate restTemplate = new RestTemplate();
+
+    private final GoogleCredentials googleCredentials;
+
+    @Value("${translation.google.project-id}")
+    private String projectId;
+
+    @Override
+    public String translate(String text, LanguageSelection sourceLang, LanguageSelection targetLang) {
+        String url = "https://translation.googleapis.com/v3/projects/" + projectId + ":translateText";
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setBearerAuth(getAccessToken()); // "Authorization: Bearer {token}"
+        headers.setContentType(MediaType.APPLICATION_JSON);
+
+        Map<String, Object> requestBody = Map.of(
+                "sourceLanguageCode", sourceLang.getCode(),
+                "targetLanguageCode", targetLang.getCode(),
+                "contents", Collections.singletonList(text)
+        );
+
+        HttpEntity<Map<String, Object>> request = new HttpEntity<>(requestBody, headers);
+
+        try {
+            ResponseEntity<Map> response = restTemplate.exchange(
+                    url,
+                    HttpMethod.POST,
+                    request,
+                    Map.class
+            );
+
+            Map<String, Object> body = response.getBody();
+            if (body == null || !body.containsKey("translations")) {
+                throw new RuntimeException("Google 번역 API 응답이 유효하지 않은 형식입니다.\n응답 내용: " + body);
+            }
+
+            @SuppressWarnings("unchecked")
+            List<Map<String, String>> translations = (List<Map<String, String>>) body.get("translations");
+            return translations.get(0).get("translatedText");
+
+        } catch (Exception e) {
+            throw new IllegalStateException("Google 번역 API 호출 실패", e);
+        }
+    }
+
+    public String getAccessToken() {
+        try {
+            synchronized (googleCredentials) {
+                googleCredentials.refreshIfExpired();
+                return googleCredentials.getAccessToken().getTokenValue();
+            }
+        } catch (Exception e) {
+            throw new IllegalStateException("Google access token 발급 실패", e);
+        }
+    }
+}

--- a/src/main/java/flab/transtalk/translation/service/translation/TranslateService.java
+++ b/src/main/java/flab/transtalk/translation/service/translation/TranslateService.java
@@ -1,5 +1,7 @@
 package flab.transtalk.translation.service.translation;
 
+import flab.transtalk.common.enums.LanguageSelection;
+import flab.transtalk.common.enums.TranslationProviderSelection;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -10,5 +12,16 @@ import java.util.Map;
 public class TranslateService {
 
     private final Map<String, TranslationProvider> providers;
+
+    public String translate(TranslationProviderSelection providerSelection,
+                            String text,
+                            LanguageSelection sourceLanguage,
+                            LanguageSelection targetLanguage){
+        TranslationProvider provider = providers.get(providerSelection.getProviderKey());
+        if (provider == null){
+            throw new IllegalArgumentException("No provider found for: " + providerSelection.getProviderKey());
+        }
+        return provider.translate(text, sourceLanguage, targetLanguage);
+    }
 
 }

--- a/src/main/java/flab/transtalk/translation/service/translation/TranslateService.java
+++ b/src/main/java/flab/transtalk/translation/service/translation/TranslateService.java
@@ -1,0 +1,14 @@
+package flab.transtalk.translation.service.translation;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+public class TranslateService {
+
+    private final Map<String, TranslationProvider> providers;
+
+}

--- a/src/main/java/flab/transtalk/translation/service/translation/TranslationProvider.java
+++ b/src/main/java/flab/transtalk/translation/service/translation/TranslationProvider.java
@@ -1,0 +1,7 @@
+package flab.transtalk.translation.service.translation;
+
+import flab.transtalk.common.enums.LanguageSelection;
+
+public interface TranslationProvider {
+    String translate(String text, LanguageSelection sourceLang, LanguageSelection targetLang);
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -90,3 +90,7 @@ app:
         - /*
       cookie:
         use-parent-domain: ${CLOUDFRONT_COOKIE_USE_PARENT_DOMAIN}
+
+translation:
+  google:
+    credentials-path: ${GOOGLE_CLOUD_API_CREDENTIALS_PATH_FOR_TRANSLATION}


### PR DESCRIPTION
## 작업 대상
- issue
    - #11 

## 작업 내용 요약
- 채팅 발생 시 원문에 대응되는 번역 결과가 자동으로 구해지도록 외부 API와 연계하였다.
- 만약 번역이 실패될 경우 채팅 원문 또한 저장되지 않도록 하여 송신 실패 기준을 강화하였다.
- 채팅방 참가자들의 프로필 설정 언어를 기준으로 번역이 수행되도록 하였다.
- 번역 수단의 확장성을 고려하여 TranslationProvider 인터페이스를 정의하였다.
- Google Translation API 연결 방식의 번역 기능 구현체를 추가하였다.