### PR TITLE
[#26] OpenAI provider 추가 및 provider 간의 실행 우선순위 구조화

### DIFF
--- a/src/main/java/flab/transtalk/common/enums/TranslationProviderSelection.java
+++ b/src/main/java/flab/transtalk/common/enums/TranslationProviderSelection.java
@@ -1,6 +1,7 @@
 package flab.transtalk.common.enums;
 
 public enum TranslationProviderSelection {
+    OPENAI("openai"),
     GOOGLE("google");
 
     private final String providerKey;

--- a/src/main/java/flab/transtalk/common/exception/handler/SystemExceptionHandler.java
+++ b/src/main/java/flab/transtalk/common/exception/handler/SystemExceptionHandler.java
@@ -23,4 +23,14 @@ public class SystemExceptionHandler {
         );
         return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(new ApiErrorResponse("SIGNED_COOKIE_ERROR", errors));
     }
+
+    @ExceptionHandler(IllegalStateException.class)
+    public ResponseEntity<ApiErrorResponse> handleIllegalStateException(IllegalStateException e) {
+        log.error("IllegalStateException 발생", e);
+
+        List<String> errors = List.of(
+                e.getMessage()
+        );
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(new ApiErrorResponse("INTERNAL_SERVER_ERROR", errors));
+    }
 }

--- a/src/main/java/flab/transtalk/translation/dto/req/ChatMessageRequestDto.java
+++ b/src/main/java/flab/transtalk/translation/dto/req/ChatMessageRequestDto.java
@@ -7,5 +7,5 @@ import lombok.Getter;
 public class ChatMessageRequestDto {
     private Long chatRoomId;
     private String content;
-    private TranslationProviderSelection providerSelection = TranslationProviderSelection.GOOGLE;
+    private TranslationProviderSelection providerSelection;
 }

--- a/src/main/java/flab/transtalk/translation/service/chatmessage/ChatMessageService.java
+++ b/src/main/java/flab/transtalk/translation/service/chatmessage/ChatMessageService.java
@@ -85,7 +85,7 @@ public class ChatMessageService {
             throw new ExternalApiUnavailableException(
                     String.format(
                             ExceptionMessages.TRANSLATION_SERVICE_UNAVAILABLE,
-                            request.getProviderSelection().getProviderKey()
+                            (request.getProviderSelection().getProviderKey()!=null? request.getProviderSelection().getProviderKey(): "default provider")
                     ));
         }
 

--- a/src/main/java/flab/transtalk/translation/service/translation/GoogleTranslationProvider.java
+++ b/src/main/java/flab/transtalk/translation/service/translation/GoogleTranslationProvider.java
@@ -50,7 +50,7 @@ public class GoogleTranslationProvider implements TranslationProvider {
 
             Map<String, Object> body = response.getBody();
             if (body == null || !body.containsKey("translations")) {
-                throw new RuntimeException("Google 번역 API 응답이 유효하지 않은 형식입니다.\n응답 내용: " + body);
+                throw new IllegalStateException("Google 번역 API 응답이 유효하지 않은 형식입니다.");
             }
 
             @SuppressWarnings("unchecked")

--- a/src/main/java/flab/transtalk/translation/service/translation/OpenaiTranslationProvider.java
+++ b/src/main/java/flab/transtalk/translation/service/translation/OpenaiTranslationProvider.java
@@ -1,0 +1,93 @@
+package flab.transtalk.translation.service.translation;
+
+import flab.transtalk.common.enums.LanguageSelection;
+import org.springframework.stereotype.Component;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.*;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.List;
+import java.util.Map;
+
+
+@Component("openai")
+@RequiredArgsConstructor
+public class OpenaiTranslationProvider implements TranslationProvider {
+
+    private final RestTemplate restTemplate = new RestTemplate();
+
+    @Value("${translation.openai.api-key}")
+    private String apiKey;
+
+    @Value("${translation.openai.prompt-id}")
+    private String promptId; // ex: pmpt_6928xxxx...
+
+    @Value("${translation.openai.prompt-version}")
+    private String promptVersion; // ex: 3
+
+    @Value("${translation.openai.model-id}")
+    private String modelId; // ex: gpt-5-nano-2025-08-07
+
+    @Override
+    public String translate(String text, LanguageSelection sourceLang, LanguageSelection targetLang) {
+
+        String url = "https://api.openai.com/v1/responses";
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setBearerAuth(apiKey);
+        headers.setContentType(MediaType.APPLICATION_JSON);
+
+        // Prompt Variables 매핑
+        Map<String, Object> variables = Map.of(
+                "sourcelang", sourceLang.getCode(),
+                "targetlang", targetLang.getCode(),
+                "content", text
+        );
+
+        // Prompt 객체 생성
+        Map<String, Object> promptObject = Map.of(
+                "id", promptId,
+                "version", promptVersion,
+                "variables", variables
+        );
+
+        // 요청 body
+        Map<String, Object> requestBody = Map.of(
+                "model", modelId,
+                "prompt", promptObject
+        );
+
+        HttpEntity<Map<String, Object>> request = new HttpEntity<>(requestBody, headers);
+
+        try {
+            ResponseEntity<Map> response = restTemplate.exchange(
+                    url,
+                    HttpMethod.POST,
+                    request,
+                    Map.class
+            );
+
+            Map<String, Object> body = response.getBody();
+            if (body == null || !body.containsKey("output")) {
+                throw new IllegalStateException("OpenAI 응답이 잘못되었습니다. body=" + body);
+            }
+
+            // output -> 배열 형태이며 message 아이템 포함
+            @SuppressWarnings("unchecked")
+            List<Map<String, Object>> outputList = (List<Map<String, Object>>) body.get("output");
+
+            // 두 번째 output 블록
+            var messageBlock = outputList.get(1);
+
+            // content.text 부분 추출
+            @SuppressWarnings("unchecked")
+            List<Map<String, Object>> contentList = (List<Map<String, Object>>) messageBlock.get("content");
+
+            return contentList.get(0).get("text").toString().trim();
+
+        } catch (Exception e) {
+            throw new IllegalStateException("OpenAI 번역 API 호출 실패", e);
+        }
+    }
+}

--- a/src/main/java/flab/transtalk/translation/service/translation/OpenaiTranslationProvider.java
+++ b/src/main/java/flab/transtalk/translation/service/translation/OpenaiTranslationProvider.java
@@ -31,7 +31,6 @@ public class OpenaiTranslationProvider implements TranslationProvider {
 
     @Override
     public String translate(String text, LanguageSelection sourceLang, LanguageSelection targetLang) {
-
         String url = "https://api.openai.com/v1/responses";
 
         HttpHeaders headers = new HttpHeaders();
@@ -70,7 +69,7 @@ public class OpenaiTranslationProvider implements TranslationProvider {
 
             Map<String, Object> body = response.getBody();
             if (body == null || !body.containsKey("output")) {
-                throw new IllegalStateException("OpenAI 응답이 잘못되었습니다. body=" + body);
+                throw new IllegalStateException("OpenAI 응답이 잘못되었습니다.");
             }
 
             // output -> 배열 형태이며 message 아이템 포함

--- a/src/main/java/flab/transtalk/translation/service/translation/TranslateService.java
+++ b/src/main/java/flab/transtalk/translation/service/translation/TranslateService.java
@@ -3,13 +3,21 @@ package flab.transtalk.translation.service.translation;
 import flab.transtalk.common.enums.LanguageSelection;
 import flab.transtalk.common.enums.TranslationProviderSelection;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class TranslateService {
+
+    @Value("${translation.default-provider:GOOGLE}")
+    private TranslationProviderSelection defaultProvider;
 
     private final Map<String, TranslationProvider> providers;
 
@@ -17,11 +25,43 @@ public class TranslateService {
                             String text,
                             LanguageSelection sourceLanguage,
                             LanguageSelection targetLanguage){
-        TranslationProvider provider = providers.get(providerSelection.getProviderKey());
-        if (provider == null){
-            throw new IllegalArgumentException("No provider found for: " + providerSelection.getProviderKey());
+        if (providerSelection == null){
+            providerSelection = defaultProvider;
         }
-        return provider.translate(text, sourceLanguage, targetLanguage);
+
+        String primaryKey = providerSelection.getProviderKey();
+
+        List<Map.Entry<String, TranslationProvider>> orderedProviders = new ArrayList<>();
+
+        TranslationProvider primary = providers.get(primaryKey);
+        if (primary != null) {
+            orderedProviders.add(Map.entry(primaryKey, primary));
+        } else {
+            throw new IllegalArgumentException("No provider found for: " + primaryKey);
+        }
+
+        for (Map.Entry<String, TranslationProvider> entry : providers.entrySet()) {
+            if (!entry.getKey().equals(primaryKey)) {
+                orderedProviders.add(entry);
+            }
+        }
+
+        if (orderedProviders.isEmpty()) {
+            throw new IllegalStateException("등록된 번역 Provider가 없습니다.");
+        }
+
+        for (Map.Entry<String, TranslationProvider> entry : orderedProviders) {
+            String key = entry.getKey();
+            TranslationProvider provider = entry.getValue();
+
+            try {
+                return provider.translate(text, sourceLanguage, targetLanguage);
+            } catch (RuntimeException ex) {
+                log.warn("Translation provider '{}' failed: {}", key, ex.getMessage(), ex);
+            }
+        }
+
+        throw new IllegalStateException("모든 번역 provider 호출에 실패했습니다.");
     }
 
 }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -93,4 +93,10 @@ app:
 
 translation:
   google:
+    project-id: ${GOOGLE_CLOUD_API_PROJECT_ID_FOR_TRANSLATION}
     credentials-path: ${GOOGLE_CLOUD_API_CREDENTIALS_PATH_FOR_TRANSLATION}
+  openai:
+    api-key: ${OPENAI_API_SECRET_KEY}
+    prompt-id: ${OPENAI_API_PROMPT_ID}
+    prompt-version: ${OPENAI_API_PROMPT_VERSION}
+    model-id: ${OPENAI_API_MODEL_ID}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -92,6 +92,7 @@ app:
         use-parent-domain: ${CLOUDFRONT_COOKIE_USE_PARENT_DOMAIN}
 
 translation:
+  default-provider: ${TRANSLATION_DEFAULT_PROVIDER}
   google:
     project-id: ${GOOGLE_CLOUD_API_PROJECT_ID_FOR_TRANSLATION}
     credentials-path: ${GOOGLE_CLOUD_API_CREDENTIALS_PATH_FOR_TRANSLATION}


### PR DESCRIPTION
## 작업 대상
- issue
    - #26 

## 작업 요약
- OpenAI API(외부 API)를 사용하여 변역을 수행하도록 하는 기능(클래스)을 추가로 정의하였다.
- 프롬프트를 코드 수정 없이 신속하게 변경할 수 있도록 openai 플레이그라운드 상에 정의한 프롬프트를 환경변수를 통해 식별하여 사용하도록 구성하였다. 속성 주입 방식으로 진행되며 출발 언어, 도착 언어, 원문을 지정된 프롬프트로 송신하여 구동한 후 응답을 받는다.
- 어떤 provider를 가장 우선하여 사용할 것인지를 환경변수를 통해 임의로 설정할 수 있도록 구성하였다.
- 외부 API에 의존하는 provider들의 안정성을 보완하기 위해, 번역 기능을 제공할 provider에 우선순위를 두어 장애 발생이 확인될 경우 순차적으로 예비 provider를 구동하여 반환하도록 구조화하였다. 반환이 발생할 경우 정상 동작으로 인지하고 그 이외의 경우 예외로 처리하였다.
